### PR TITLE
Implement additional core voxel fit functions

### DIFF
--- a/R/core_voxelfit_engine.R
+++ b/R/core_voxelfit_engine.R
@@ -61,3 +61,126 @@ solve_glm_for_gamma_core <- function(Z_list_of_matrices,
   beta
 }
 
+
+#' Extract raw manifold coordinates and condition amplitudes via SVD
+#'
+#' @param Gamma_coeffs_matrix (k*m) x V matrix of gamma coefficients
+#' @param m_manifold_dim Integer manifold dimension m
+#' @param k_conditions Integer number of conditions k
+#' @return list with Xi_raw_matrix (m x V) and Beta_raw_matrix (k x V)
+#' @export
+extract_xi_beta_raw_svd_core <- function(Gamma_coeffs_matrix,
+                                         m_manifold_dim,
+                                         k_conditions) {
+  if (!is.matrix(Gamma_coeffs_matrix)) {
+    stop("Gamma_coeffs_matrix must be a matrix")
+  }
+  if (nrow(Gamma_coeffs_matrix) != m_manifold_dim * k_conditions) {
+    stop("nrow(Gamma_coeffs_matrix) must equal m*k")
+  }
+  V <- ncol(Gamma_coeffs_matrix)
+  Xi_raw <- matrix(0, m_manifold_dim, V)
+  Beta_raw <- matrix(0, k_conditions, V)
+  for (v in seq_len(V)) {
+    Gv <- matrix(Gamma_coeffs_matrix[, v], nrow = m_manifold_dim, ncol = k_conditions)
+    sv <- svd(Gv)
+    if (length(sv$d) == 0 || sv$d[1] < .Machine$double.eps) {
+      next
+    }
+    Xi_raw[, v] <- sv$u[, 1] * sqrt(sv$d[1])
+    Beta_raw[, v] <- sv$v[, 1] * sqrt(sv$d[1])
+  }
+  list(Xi_raw_matrix = Xi_raw, Beta_raw_matrix = Beta_raw)
+}
+
+#' Apply intrinsic identifiability constraints
+#'
+#' @param Xi_raw_matrix m x V matrix of raw manifold coordinates
+#' @param Beta_raw_matrix k x V matrix of raw condition amplitudes
+#' @param B_reconstructor_matrix p x m manifold reconstructor
+#' @param h_ref_shape_vector p-length canonical HRF shape
+#' @param ident_scale_method one of "l2_norm", "max_abs_val", "none"
+#' @param ident_sign_method one of "first_component", "canonical_correlation"
+#' @return list with Xi_ident_matrix and Beta_ident_matrix
+#' @export
+apply_intrinsic_identifiability_core <- function(Xi_raw_matrix,
+                                                 Beta_raw_matrix,
+                                                 B_reconstructor_matrix,
+                                                 h_ref_shape_vector,
+                                                 ident_scale_method = c("l2_norm", "max_abs_val", "none"),
+                                                 ident_sign_method = c("first_component", "canonical_correlation")) {
+  ident_scale_method <- match.arg(ident_scale_method)
+  ident_sign_method <- match.arg(ident_sign_method)
+
+  xi_ref_coord <- MASS::ginv(B_reconstructor_matrix) %*% h_ref_shape_vector
+
+  V <- ncol(Xi_raw_matrix)
+  Xi_ident <- matrix(0, nrow(Xi_raw_matrix), V)
+  Beta_ident <- matrix(0, nrow(Beta_raw_matrix), V)
+
+  for (v in seq_len(V)) {
+    xi_v <- Xi_raw_matrix[, v]
+    beta_v <- Beta_raw_matrix[, v]
+
+    if (ident_sign_method == "canonical_correlation") {
+      sgn <- sign(sum(xi_v * xi_ref_coord))
+      if (sgn == 0) sgn <- 1
+    } else { # first_component
+      sgn <- sign(xi_v[1])
+      if (sgn == 0) sgn <- 1
+    }
+
+    xi_v <- xi_v * sgn
+    beta_v <- beta_v * sgn
+
+    hrf_v <- B_reconstructor_matrix %*% xi_v
+    scale_val <- 1
+    if (ident_scale_method == "l2_norm") {
+      scale_val <- 1 / pmax(sqrt(sum(hrf_v^2)), .Machine$double.eps)
+    } else if (ident_scale_method == "max_abs_val") {
+      scale_val <- 1 / pmax(max(abs(hrf_v)), .Machine$double.eps)
+    }
+    Xi_ident[, v] <- xi_v * scale_val
+    Beta_ident[, v] <- beta_v / scale_val
+  }
+
+  list(Xi_ident_matrix = Xi_ident, Beta_ident_matrix = Beta_ident)
+}
+
+#' Construct voxel graph Laplacian
+#'
+#' @param voxel_coords_matrix V x 3 matrix of voxel coordinates
+#' @param num_neighbors_Lsp number of nearest neighbours
+#' @return sparse V x V graph Laplacian matrix
+#' @export
+make_voxel_graph_laplacian_core <- function(voxel_coords_matrix, num_neighbors_Lsp = 6) {
+  nn <- RANN::nn2(voxel_coords_matrix, k = num_neighbors_Lsp + 1)
+  i_idx <- rep(seq_len(nrow(voxel_coords_matrix)), each = num_neighbors_Lsp)
+  j_idx <- as.vector(nn$nn.idx[, -1])
+  W <- Matrix::sparseMatrix(i = i_idx, j = j_idx, x = 1,
+                            dims = c(nrow(voxel_coords_matrix), nrow(voxel_coords_matrix)))
+  W <- (W + t(W)) / 2
+  D <- Matrix::Diagonal(x = Matrix::rowSums(W))
+  L <- D - W
+  L
+}
+
+#' Apply spatial smoothing to manifold coordinates
+#'
+#' @param Xi_ident_matrix m x V matrix of manifold coordinates
+#' @param L_sp_sparse_matrix V x V Laplacian matrix
+#' @param lambda_spatial_smooth smoothing strength
+#' @return Xi_smoothed_matrix m x V matrix
+#' @export
+apply_spatial_smoothing_core <- function(Xi_ident_matrix,
+                                         L_sp_sparse_matrix,
+                                         lambda_spatial_smooth) {
+  V <- ncol(Xi_ident_matrix)
+  A <- Matrix::Diagonal(V) + lambda_spatial_smooth * L_sp_sparse_matrix
+  Xi_smoothed <- Xi_ident_matrix
+  for (j in seq_len(nrow(Xi_ident_matrix))) {
+    Xi_smoothed[j, ] <- as.vector(Matrix::solve(A, Xi_ident_matrix[j, ]))
+  }
+  Xi_smoothed
+}
+

--- a/tests/testthat/test-core-voxelfit-engine.R
+++ b/tests/testthat/test-core-voxelfit-engine.R
@@ -1,0 +1,40 @@
+context("core voxel fit engine")
+
+set.seed(1)
+
+m <- 2
+k <- 3
+V <- 4
+Gamma <- matrix(rnorm(m * k * V), m * k, V)
+
+ test_that("extract_xi_beta_raw_svd_core returns correct dimensions", {
+   res <- extract_xi_beta_raw_svd_core(Gamma, m, k)
+   expect_equal(dim(res$Xi_raw_matrix), c(m, V))
+   expect_equal(dim(res$Beta_raw_matrix), c(k, V))
+ })
+
+ test_that("apply_intrinsic_identifiability_core works", {
+   Xi_raw <- matrix(rnorm(m * V), m, V)
+   Beta_raw <- matrix(rnorm(k * V), k, V)
+   B <- matrix(rnorm(5 * m), 5, m)
+   h_ref <- rnorm(5)
+   res <- apply_intrinsic_identifiability_core(Xi_raw, Beta_raw, B, h_ref)
+   expect_equal(dim(res$Xi_ident_matrix), c(m, V))
+   expect_equal(dim(res$Beta_ident_matrix), c(k, V))
+ })
+
+ test_that("make_voxel_graph_laplacian_core returns sparse Laplacian", {
+   coords <- matrix(seq_len(9), ncol = 3)
+   L <- make_voxel_graph_laplacian_core(coords, num_neighbors_Lsp = 2)
+   expect_s4_class(L, "dgCMatrix")
+   expect_equal(dim(L), c(nrow(coords), nrow(coords)))
+ })
+
+ test_that("apply_spatial_smoothing_core returns same dimension", {
+   coords <- matrix(seq_len(9), ncol = 3)
+   L <- make_voxel_graph_laplacian_core(coords, num_neighbors_Lsp = 2)
+   Xi <- matrix(rnorm(m * nrow(coords)), m, nrow(coords))
+   Xi_s <- apply_spatial_smoothing_core(Xi, L, 0.1)
+   expect_equal(dim(Xi_s), dim(Xi))
+ })
+


### PR DESCRIPTION
## Summary
- add SVD-based extraction of voxel manifold parameters
- add intrinsic identifiability, Laplacian construction, and smoothing helpers
- test new core voxel fitting helpers

## Testing
- `devtools::test()` *(fails: `R` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683aebe1aa80832dbc2f7c94323a8cbb