### PR TITLE
Fix create_hrf_manifold canonical dependency handling

### DIFF
--- a/R/mhrf_lss_interface.R
+++ b/R/mhrf_lss_interface.R
@@ -242,6 +242,9 @@ create_hrf_manifold <- function(hrf_library, params, TR, verbose = TRUE) {
   # Handle different library sources
   if (is.character(hrf_library) && length(hrf_library) == 1) {
     if (hrf_library == "canonical") {
+      if (!requireNamespace("fmrireg", quietly = TRUE)) {
+        stop("Package 'fmrireg' is required to use the canonical HRF library.")
+      }
       # Use standard fmrireg HRFs
       if (verbose) message("  Using canonical fmrireg HRF library")
       

--- a/tests/testthat/test-mhrf-lss-interface.R
+++ b/tests/testthat/test-mhrf-lss-interface.R
@@ -34,6 +34,7 @@ test_that("mhrf_lss interface validates inputs correctly", {
 })
 
 test_that("create_hrf_manifold handles different input types", {
+  skip_if_not_installed("fmrireg")
   # Test with preset parameters
   expect_silent(
     manifold1 <- create_hrf_manifold(


### PR DESCRIPTION
## Summary
- ensure `create_hrf_manifold()` checks that **fmrireg** is installed when using the canonical library
- skip manifold construction tests if **fmrireg** is not available

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b27191494832db980bf42569b3b0e