### PR TITLE
Remove devtools load_all calls from tests

### DIFF
--- a/tests/testthat/test-debug-woodbury.R
+++ b/tests/testthat/test-debug-woodbury.R
@@ -1,6 +1,5 @@
 # Debug script for Woodbury LSS implementation
 library(testthat)
-devtools::load_all()
 
 # Simple test case
 set.seed(42)

--- a/tests/testthat/test-lss-correction-validation.R
+++ b/tests/testthat/test-lss-correction-validation.R
@@ -1,6 +1,5 @@
 # Test the corrected LSS implementation
 library(testthat)
-devtools::load_all()
 
 test_that("Corrected LSS implementation matches ground truth", {
   

--- a/tests/testthat/test-lss-formula-verification.R
+++ b/tests/testthat/test-lss-formula-verification.R
@@ -1,6 +1,5 @@
 # Verify the LSS formula implementation against reference
 library(testthat)
-devtools::load_all()
 
 # Helper function: Solve for A^+ using Cholesky
 cholSolve <- function(A, B) {

--- a/tests/testthat/test-woodbury-mathematical-verification.R
+++ b/tests/testthat/test-woodbury-mathematical-verification.R
@@ -4,7 +4,6 @@
 # by working through the algebra step by step
 
 library(testthat)
-devtools::load_all()
 
 # ============================================================================
 # MATHEMATICAL BACKGROUND


### PR DESCRIPTION
## Summary
- remove `devtools::load_all()` usage from tests

## Testing
- ❌ `R CMD check` *(fails: `bash: R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683b28d7d388832db8b187fbc515236c