### PR TITLE
Add missing LSS formula validation

### DIFF
--- a/tests/testthat/test-lss-formula-verification.R
+++ b/tests/testthat/test-lss-formula-verification.R
@@ -103,6 +103,8 @@ test_that("Current LSS formula matches reference implementation", {
   cat("Reference:  ", round(betas_ref, 4), "\n")
   cat("Current:    ", round(betas_current, 4), "\n")
   cat("Difference: ", round(betas_current - betas_ref, 6), "\n")
+
+  expect_equal(betas_current, betas_ref, tolerance = 1e-6)
 })
 
 


### PR DESCRIPTION
## Summary
- add test expectation to ensure current LSS implementation matches the reference computation

## Testing
- `devtools::test()` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683b28da8d88832dac245883fd8a0baf