### PR TITLE
Handle near-zero HRFs in identifiability step

### DIFF
--- a/R/core_voxelfit_engine.R
+++ b/R/core_voxelfit_engine.R
@@ -139,6 +139,9 @@ extract_xi_beta_raw_svd_core <- function(Gamma_coeffs_matrix,
 #' @param h_ref_shape_vector p-length canonical HRF shape
 #' @param ident_scale_method one of "l2_norm", "max_abs_val", "none"
 #' @param ident_sign_method one of "first_component", "canonical_correlation"
+#' @param zero_tol numeric tolerance for treating a reconstructed HRF as zero.
+#'   Voxels with L2 norm or maximum absolute value below this threshold are
+#'   zeroed in both \code{Xi_ident_matrix} and \code{Beta_ident_matrix}.
 #' @return list with Xi_ident_matrix and Beta_ident_matrix
 #' @export
 apply_intrinsic_identifiability_core <- function(Xi_raw_matrix,
@@ -146,7 +149,8 @@ apply_intrinsic_identifiability_core <- function(Xi_raw_matrix,
                                                  B_reconstructor_matrix,
                                                  h_ref_shape_vector,
                                                  ident_scale_method = c("l2_norm", "max_abs_val", "none"),
-                                                 ident_sign_method = c("first_component", "canonical_correlation")) {
+                                                 ident_sign_method = c("first_component", "canonical_correlation"),
+                                                 zero_tol = 1e-8) {
   ident_scale_method <- match.arg(ident_scale_method)
   ident_sign_method <- match.arg(ident_sign_method)
 
@@ -174,9 +178,21 @@ apply_intrinsic_identifiability_core <- function(Xi_raw_matrix,
     hrf_v <- B_reconstructor_matrix %*% xi_v
     scale_val <- 1
     if (ident_scale_method == "l2_norm") {
-      scale_val <- 1 / pmax(sqrt(sum(hrf_v^2)), .Machine$double.eps)
+      l2_norm <- sqrt(sum(hrf_v^2))
+      if (l2_norm < zero_tol) {
+        Xi_ident[, v] <- 0
+        Beta_ident[, v] <- 0
+        next
+      }
+      scale_val <- 1 / pmax(l2_norm, .Machine$double.eps)
     } else if (ident_scale_method == "max_abs_val") {
-      scale_val <- 1 / pmax(max(abs(hrf_v)), .Machine$double.eps)
+      max_abs <- max(abs(hrf_v))
+      if (max_abs < zero_tol) {
+        Xi_ident[, v] <- 0
+        Beta_ident[, v] <- 0
+        next
+      }
+      scale_val <- 1 / pmax(max_abs, .Machine$double.eps)
     }
     Xi_ident[, v] <- xi_v * scale_val
     Beta_ident[, v] <- beta_v / scale_val

--- a/man/apply_intrinsic_identifiability_core.Rd
+++ b/man/apply_intrinsic_identifiability_core.Rd
@@ -10,8 +10,9 @@ apply_intrinsic_identifiability_core(
   B_reconstructor_matrix,
   h_ref_shape_vector,
   ident_scale_method = "l2_norm",
-  ident_sign_method = "canonical_correlation"
-)
+  ident_sign_method = "canonical_correlation",
+  zero_tol = 1e-8
+  )
 }
 \arguments{
 \item{Xi_raw_matrix}{The m x V raw manifold coordinates from extract_xi_beta_raw_svd_core}
@@ -27,6 +28,10 @@ apply_intrinsic_identifiability_core(
 
 \item{ident_sign_method}{Sign alignment method: "canonical_correlation" (align with
 reference) or "data_fit_correlation" (requires additional data, not implemented)}
+\item{zero_tol}{Tolerance for treating the reconstructed HRF as zero. If the
+L2 norm (for \code{"l2_norm"}) or maximum absolute value (for \code{"max_abs_val"})
+is below this threshold, both \code{Xi_ident_matrix} and \code{Beta_ident_matrix}
+are set to zero for the voxel.}
 }
 \value{
 A list containing:
@@ -45,6 +50,8 @@ It ensures that HRF estimates are identifiable by:
 \item Aligning sign with a reference HRF (avoiding arbitrary sign flips)
 \item Normalizing scale consistently across voxels
 The beta amplitudes are adjusted inversely to preserve the overall signal.
+Voxels whose reconstructed HRFs have magnitude below \code{zero_tol} are set to
+zero in both returned matrices.
 }
 }
 \examples{

--- a/tests/testthat/test-voxelwise-fit.R
+++ b/tests/testthat/test-voxelwise-fit.R
@@ -743,6 +743,30 @@ test_that("apply_intrinsic_identifiability_core handles zero voxels", {
   # Zero voxels should remain zero
   expect_equal(result$Xi_ident_matrix[, zero_voxels], matrix(0, m, length(zero_voxels)))
   
-  # Beta can be non-zero for zero Xi (but will be set to 0 if scale is inf)
-  expect_equal(result$Beta_ident_matrix[, zero_voxels], Beta_raw[, zero_voxels])
+  # Both Xi and Beta should be zero for these voxels
+  expect_equal(result$Beta_ident_matrix[, zero_voxels], matrix(0, k, length(zero_voxels)))
+})
+
+test_that("apply_intrinsic_identifiability_core zeros tiny HRFs", {
+  set.seed(987)
+  m <- 3
+  k <- 2
+  V <- 5
+  p <- 10
+
+  Xi_raw <- matrix(rnorm(m * V), m, V)
+  Beta_raw <- matrix(rnorm(k * V), k, V)
+  B_reconstructor <- matrix(rnorm(p * m), p, m)
+  h_ref <- rnorm(p)
+
+  tiny_voxel <- 1
+  Xi_raw[, tiny_voxel] <- 1e-12
+
+  result <- apply_intrinsic_identifiability_core(
+    Xi_raw, Beta_raw, B_reconstructor, h_ref,
+    ident_scale_method = "l2_norm"
+  )
+
+  expect_equal(result$Xi_ident_matrix[, tiny_voxel], rep(0, m))
+  expect_equal(result$Beta_ident_matrix[, tiny_voxel], rep(0, k))
 })


### PR DESCRIPTION
## Summary
- zero out voxel estimates when HRF scale is below tolerance
- expose `zero_tol` argument in `apply_intrinsic_identifiability_core`
- update docs for the new behaviour
- adjust tests for zero voxels and add a test for tiny HRFs

## Testing
- `devtools::test()` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683b2fb022a0832db8ff97d792c824e4