### PR TITLE
Remove duplicate %||% operator

### DIFF
--- a/R/mhrf_lss_interface.R
+++ b/R/mhrf_lss_interface.R
@@ -814,13 +814,3 @@ extract_hrf_stats <- function(H_shapes) {
   )
 }
 
-
-# Null-coalesce operator
-#'
-#' Returns \code{y} if \code{x} is \code{NULL}, otherwise \code{x}.
-#'
-#' @param x Primary value to return if not \code{NULL}.
-#' @param y Fallback value to return if \code{x} is \code{NULL}.
-#' @return \code{x} if not \code{NULL}, otherwise \code{y}.
-#' @export
-`%||%` <- function(x, y) if (is.null(x)) y else x


### PR DESCRIPTION
## Summary
- remove redundant `%||%` operator definition
- clean up trailing comments

## Testing
- `R -q -e 'devtools::test()'` *(fails: `R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683c61d9fa7c832d9efe1949cdb19afd