### PR TITLE
Implement neuroimaging wrappers and HRF library

### DIFF
--- a/R/core_voxelwise_fit.R
+++ b/R/core_voxelwise_fit.R
@@ -504,7 +504,9 @@ apply_intrinsic_identifiability_core <- function(Xi_raw_matrix,
                                                 h_ref_shape_vector,
                                                 ident_scale_method = "l2_norm",
                                                 ident_sign_method = "canonical_correlation",
-                                                zero_tol = 1e-8) {
+                                                zero_tol = 1e-8,
+                                                Y_proj_matrix = NULL,
+                                                X_condition_list_proj_matrices = NULL) {
   
   # Input validation
   if (!is.matrix(Xi_raw_matrix)) {
@@ -553,7 +555,9 @@ apply_intrinsic_identifiability_core <- function(Xi_raw_matrix,
   }
   
   if (ident_sign_method == "data_fit_correlation") {
-    stop("data_fit_correlation method requires additional data inputs and is not yet implemented")
+    if (is.null(Y_proj_matrix) || is.null(X_condition_list_proj_matrices)) {
+      stop("data_fit_correlation method requires Y_proj_matrix and X_condition_list_proj_matrices")
+    }
   }
   
   # Compute reference manifold coordinates
@@ -581,8 +585,28 @@ apply_intrinsic_identifiability_core <- function(Xi_raw_matrix,
     if (ident_sign_method == "canonical_correlation") {
       # Align sign based on correlation with reference
       sgn <- sign(sum(xi_vx * xi_ref_coord))
-      # Handle case where correlation is exactly zero
       if (sgn == 0) sgn <- 1
+    } else if (ident_sign_method == "data_fit_correlation") {
+      best_r2 <- -Inf
+      best_sgn <- 1
+      for (sg in c(1, -1)) {
+        xi_tmp <- xi_vx * sg
+        beta_tmp <- beta_vx * sg
+        h_tmp <- B_reconstructor_matrix %*% xi_tmp
+        k <- length(X_condition_list_proj_matrices)
+        X_design <- matrix(0, nrow(Y_proj_matrix), k)
+        for (c in 1:k) {
+          X_design[, c] <- X_condition_list_proj_matrices[[c]] %*% h_tmp
+        }
+        y_pred <- X_design %*% beta_tmp
+        y_true <- Y_proj_matrix[, vx]
+        r2 <- suppressWarnings(cor(y_pred, y_true))^2
+        if (!is.na(r2) && r2 > best_r2) {
+          best_r2 <- r2
+          best_sgn <- sg
+        }
+      }
+      sgn <- best_sgn
     }
     
     # Apply sign

--- a/R/mhrf_lss_interface.R
+++ b/R/mhrf_lss_interface.R
@@ -495,7 +495,9 @@ run_mhrf_lss_standard <- function(Y_data, design_info, manifold, Z_confounds,
     B_reconstructor_matrix = manifold$B_reconstructor_matrix,
     h_ref_shape_vector = h_ref,
     ident_scale_method = "l2_norm",
-    ident_sign_method = "canonical_correlation"
+    ident_sign_method = params$ident_sign_method %||% "canonical_correlation",
+    Y_proj_matrix = proj_result$Y_proj_matrix,
+    X_condition_list_proj_matrices = proj_result$X_list_proj_matrices
   )
   
   # 6. Spatial smoothing if coordinates provided

--- a/R/mhrf_result_methods.R
+++ b/R/mhrf_result_methods.R
@@ -383,11 +383,27 @@ coef.mhrf_result <- function(object, type = "amplitudes", ...) {
 #' @param ... Additional arguments (ignored)
 #' @export
 fitted.mhrf_result <- function(object, ...) {
-  # This would require storing design matrices and doing convolution
-  # For now, return a message
-  message("Fitted values computation not yet implemented")
-  message("This requires design matrices which are not stored by default")
-  invisible(NULL)
+  if (is.null(object$design_matrices)) {
+    stop("Design matrices not available in mhrf_result object")
+  }
+
+  X_list <- object$design_matrices
+  H <- object$hrf_shapes
+  B <- object$amplitudes
+  n <- nrow(X_list[[1]])
+  V <- ncol(H)
+  k <- length(X_list)
+
+  fitted_mat <- matrix(0, n, V)
+  for (vx in seq_len(V)) {
+    y_hat <- rep(0, n)
+    for (c in seq_len(k)) {
+      y_hat <- y_hat + (X_list[[c]] %*% H[, vx]) * B[c, vx]
+    }
+    fitted_mat[, vx] <- y_hat
+  }
+
+  return(fitted_mat)
 }
 
 

--- a/R/neuroimaging_wrappers.R
+++ b/R/neuroimaging_wrappers.R
@@ -393,14 +393,58 @@ summary.mhrf_manifold <- function(object, ...) {
 process_subject_mhrf_lss_nim <- function(bold_input, mask_input, event_input,
                                         confound_input = NULL, manifold_objects,
                                         params_list) {
-  # TODO: Implement MHRF-NIM-WRAP-SUBJECT-01
-  # This would handle:
-  # - Loading BOLD data via neuroim2
-  # - Creating design matrices via fmrireg
-  # - Calling all core pipeline functions
-  # - Returning results
-  
-  stop("Not yet implemented")
+  if (!requireNamespace("neuroim2", quietly = TRUE)) {
+    stop("Package 'neuroim2' is required")
+  }
+  if (!requireNamespace("fmrireg", quietly = TRUE)) {
+    stop("Package 'fmrireg' is required")
+  }
+
+  bold <- if (inherits(bold_input, c("NeuroVec", "NeuroVol"))) {
+    bold_input
+  } else {
+    neuroim2::read_vec(bold_input)
+  }
+
+  mask <- if (inherits(mask_input, "LogicalNeuroVol")) {
+    mask_input
+  } else {
+    neuroim2::read_vol(mask_input)
+  }
+
+  events <- if (is.character(event_input)) {
+    read.csv(event_input, sep = ifelse(grepl("\\.tsv$", event_input), "\t", ","))
+  } else {
+    event_input
+  }
+
+  TR <- params_list$TR %||% stop("TR must be specified in params_list")
+
+  Y_mat <- as.matrix(bold)
+  mask_idx <- which(as.logical(mask))
+  Y_mat <- Y_mat[, mask_idx, drop = FALSE]
+
+  sframe <- fmrireg::sampling_frame(blocklens = nrow(Y_mat), TR = TR)
+  ev_model <- fmrireg::event_model(~ hrf(onset, basis = manifold_objects$manifold_hrf_basis),
+                                   data = events, sampling_frame = sframe, drop_empty = TRUE)
+  design_info <- extract_design_info(ev_model, sframe)
+
+  result <- run_mhrf_lss_standard(
+    Y_data = Y_mat,
+    design_info = design_info,
+    manifold = manifold_objects,
+    Z_confounds = confound_input,
+    voxel_coords = neuroim2::coords(mask)[mask_idx, , drop = FALSE],
+    params = params_list,
+    outlier_weights = NULL,
+    estimation = if (length(design_info$X_trial_list) > 0) "both" else "condition",
+    progress = FALSE
+  )
+
+  result$mask_indices <- mask_idx
+  result$space <- neuroim2::space(bold)
+
+  return(result)
 }
 
 #' Enhanced Results Packaging & Visualization (Neuroimaging Layer)
@@ -413,11 +457,29 @@ process_subject_mhrf_lss_nim <- function(bold_input, mask_input, event_input,
 #' @return mhrf_results S3 object with neuroim2 integration
 package_mhrf_results_nim <- function(core_results_list, reference_space, mask_vol,
                                     original_inputs, processing_metadata) {
-  # TODO: Implement MHRF-NIM-OUTPUT-01
-  # This would:
-  # - Convert matrices back to NeuroVec/NeuroVol objects
-  # - Create S3 class with print/plot/summary methods
-  # - Enable writing results to NIfTI
-  
-  stop("Not yet implemented")
+  if (!requireNamespace("neuroim2", quietly = TRUE)) {
+    stop("Package 'neuroim2' is required")
+  }
+
+  mask_idx <- which(as.logical(mask_vol))
+  p <- nrow(core_results_list$H_shapes)
+  Vtot <- prod(neuroim2::dim(reference_space))
+
+  hrf_arr <- matrix(0, p, Vtot)
+  hrf_arr[, mask_idx] <- core_results_list$H_shapes
+  hrf_vec <- neuroim2::NeuroVec(hrf_arr, reference_space)
+
+  amp_arr <- matrix(0, nrow(core_results_list$Beta_condition), Vtot)
+  amp_arr[, mask_idx] <- core_results_list$Beta_condition
+  amp_vec <- neuroim2::NeuroVec(amp_arr, reference_space)
+
+  result <- list(
+    hrfs = hrf_vec,
+    amplitudes = amp_vec,
+    matrices = core_results_list,
+    metadata = processing_metadata,
+    inputs = original_inputs
+  )
+  class(result) <- c("mhrf_results", "list")
+  return(result)
 }

--- a/R/soundness_improvements.R
+++ b/R/soundness_improvements.R
@@ -491,7 +491,10 @@ get_preset_params <- function(preset = c("conservative", "balanced", "aggressive
       use_case = "Clinical data, motion artifacts, heterogeneous quality"
     )
   )
-  
+
+  # Default sign alignment method
+  base_params$ident_sign_method <- "canonical_correlation"
+
   # Scale parameters if data scale provided
   if (!is.null(data_scale) && data_scale > 0) {
     scale_factor <- data_scale^2

--- a/tests/testthat/test-neuroimaging-wrappers.R
+++ b/tests/testthat/test-neuroimaging-wrappers.R
@@ -209,15 +209,20 @@ test_that("construct_hrf_manifold_nim handles list input", {
   expect_equal(manifold_list$library_info$n_hrfs, 3)
 })
 
-test_that("placeholder functions raise appropriate errors", {
-  # Test that unimplemented functions give clear errors
-  expect_error(
-    manifoldhrf:::process_subject_mhrf_lss_nim(NULL, NULL, NULL),
-    "not yet implemented"
-  )
+test_that("subject-level wrapper runs on minimal data", {
+  skip_if_not_installed("neuroim2")
+  skip_if_not_installed("fmrireg")
 
-  expect_error(
-    manifoldhrf:::package_mhrf_results_nim(NULL, NULL, NULL, NULL, NULL),
-    "not yet implemented"
-  )
+  space <- neuroim2::NeuroSpace(c(2, 2, 1, 5), spacing = rep(1, 4))
+  bold <- neuroim2::NeuroVec(array(rnorm(2 * 2 * 1 * 5), dim = c(2, 2, 1, 5)), space)
+  mask <- neuroim2::LogicalNeuroVol(array(TRUE, c(2, 2, 1)), neuroim2::space(bold))
+  events <- data.frame(onset = 0, condition = "A")
+
+  manifold <- construct_hrf_manifold_nim("gamma_grid", TR_precision = 1, m_manifold_dim_target = 2)
+  params <- get_preset_params("fast")
+  params$TR <- 1
+
+  res <- process_subject_mhrf_lss_nim(bold, mask, events, NULL, manifold, params)
+  expect_type(res, "list")
+  expect_true("H_shapes" %in% names(res))
 })


### PR DESCRIPTION
## Summary
- add spmg1 HRF library support
- implement data_fit_correlation sign option
- store design matrices and compute fitted values
- implement subject-level wrapper and result packaging
- update presets and tests

## Testing
- `devtools::test()` *(fails: `R` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683c662a3eec832db1b210b51f96631e