### PR TITLE
Implement fmrireg HRF list support

### DIFF
--- a/man/construct_hrf_manifold_nim.Rd
+++ b/man/construct_hrf_manifold_nim.Rd
@@ -57,8 +57,11 @@ wrapping the core manifold construction functions with fmrireg integration.
 \details{
 This function provides a neuroimaging-friendly interface to the core
 manifold construction pipeline. It handles conversion between fmrireg HRF
-objects and the matrix format required by core functions. The resulting
-manifold basis can be used directly in fmrireg model specifications.
+objects and the matrix format required by core functions. When a list of
+\code{fmrireg} HRF objects is supplied, each HRF is sampled with
+\code{fmrireg::evaluate()} at the requested precision to build the library
+matrix. The resulting manifold basis can be used directly in fmrireg model
+specifications.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-neuroimaging-wrappers.R
+++ b/tests/testthat/test-neuroimaging-wrappers.R
@@ -209,6 +209,25 @@ test_that("construct_hrf_manifold_nim handles list input", {
   expect_equal(manifold_list$library_info$n_hrfs, 3)
 })
 
+test_that("construct_hrf_manifold_nim evaluates fmrireg HRF objects", {
+  skip_if_not_installed("fmrireg")
+
+  hrf_list <- list(
+    fmrireg::HRF_SPMG1,
+    fmrireg::HRF_GAMMA
+  )
+
+  manifold_fmrireg <- construct_hrf_manifold_nim(
+    hrf_library_source = hrf_list,
+    TR_precision = 0.5,
+    m_manifold_dim_target = 2
+  )
+
+  expect_s3_class(manifold_fmrireg, "mhrf_manifold")
+  expect_equal(manifold_fmrireg$library_info$name, "custom_list")
+  expect_equal(manifold_fmrireg$parameters$n_hrfs_library, length(hrf_list))
+})
+
 test_that("subject-level wrapper runs on minimal data", {
   skip_if_not_installed("neuroim2")
   skip_if_not_installed("fmrireg")


### PR DESCRIPTION
## Summary
- enhance `construct_hrf_manifold_nim` to evaluate `fmrireg` HRF objects
- document new behavior in man page
- add unit test covering list of `fmrireg` HRFs

## Testing
- `R CMD check .` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683c7212aabc832da3f5229c69ca9059