### PR TITLE
Implement fmrireg HRF object builder

### DIFF
--- a/man/create_manifold_hrf_object.Rd
+++ b/man/create_manifold_hrf_object.Rd
@@ -7,6 +7,9 @@
 create_manifold_hrf_object(B_reconstructor, name, nbasis)
 }
 \description{
-Create Manifold HRF Object
+Wraps the manifold reconstructor matrix as a multi-basis
+\code{\link[fmrireg]{HRF}} object using \code{fmrireg::empirical_hrf} and
+\code{fmrireg::bind_basis}. Each column of \code{B_reconstructor} becomes one
+basis function.
 }
 \keyword{internal}

--- a/tests/testthat/test-neuroimaging-wrappers.R
+++ b/tests/testthat/test-neuroimaging-wrappers.R
@@ -178,12 +178,11 @@ test_that("manifold HRF basis object is created correctly", {
   hrf_basis <- manifold$manifold_hrf_basis
   
   # Check structure
-  expect_type(hrf_basis, "list")
   expect_s3_class(hrf_basis, "mhrf_basis")
-  expect_equal(hrf_basis$type, "manifold")
-  expect_equal(hrf_basis$nbasis, manifold$m_manifold_dim)
-  expect_true("evaluate" %in% names(hrf_basis))
-  expect_true(is.function(hrf_basis$evaluate))
+  expect_s3_class(hrf_basis, "HRF")
+  expect_equal(attr(hrf_basis, "nbasis"), manifold$m_manifold_dim)
+  expect_true(is.function(hrf_basis))
+  expect_type(fmrireg::evaluate(hrf_basis, 0), "double")
 })
 
 test_that("construct_hrf_manifold_nim handles list input", {


### PR DESCRIPTION
## Summary
- implement ticket MHRF-FMRIREG-003
- wrap the manifold reconstructor as a multi-basis fmrireg HRF
- update docs and tests

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c744e1040832d9fd8d649f7889986