### PR TITLE
Implement FMRIREG-005

### DIFF
--- a/R/neuroimaging_wrappers.R
+++ b/R/neuroimaging_wrappers.R
@@ -447,9 +447,6 @@ process_subject_mhrf_lss_nim <- function(bold_input, mask_input, event_input,
   if (!requireNamespace("neuroim2", quietly = TRUE)) {
     stop("Package 'neuroim2' is required")
   }
-  if (!requireNamespace("fmrireg", quietly = TRUE)) {
-    stop("Package 'fmrireg' is required")
-  }
 
   bold <- if (inherits(bold_input, c("NeuroVec", "NeuroVol"))) {
     bold_input


### PR DESCRIPTION
## Notes
- Unable to run package tests because R is not installed in this environment.

## Summary
- allow `.prepare_hrf_library()` to handle fmrireg HRF objects, lists and matrices
- remove dependency checks for fmrireg
- extend `create_hrf_manifold()` with new HRF library handling
- adjust neuroimaging wrappers to assume fmrireg is installed


------
https://chatgpt.com/codex/tasks/task_e_683c77f71bd8832dac98f4f5035a5567