### PR TITLE
Improve final beta estimation speed

### DIFF
--- a/man/estimate_final_condition_betas_core.Rd
+++ b/man/estimate_final_condition_betas_core.Rd
@@ -36,10 +36,11 @@ HRF shapes from the manifold estimation pipeline.
 \details{
 This function implements Component 4 of the M-HRF-LSS pipeline.
 It re-estimates condition-level amplitudes using the final smoothed HRF
-shapes. For each voxel, it constructs condition-specific regressors by
-convolving the design matrices with the voxel's HRF, then solves a
-ridge regression problem. The MVP version does a single pass (max_iter=1),
-but the framework supports iterative refinement between HRFs and betas.
+shapes. Regressors for all voxels are precomputed in a vectorized manner
+to avoid redundant convolutions, improving efficiency. For very large
+data sets, converting this step to C++ via Rcpp could further accelerate
+computation. The MVP version does a single pass (max_iter=1), but the
+framework supports iterative refinement between HRFs and betas.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
## Summary
- precompute voxel regressors and cross products in `estimate_final_condition_betas_core`
- mention vectorised approach and optional Rcpp speedups in docs

## Testing
- `R CMD INSTALL .` *(fails: `R` not found)*
- `R -e "devtools::test()"` *(fails: `R` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c7e8ce5ac832d9e5f8f75df80ab86