### PR TITLE
Check RcppHNSW for ann_euclidean

### DIFF
--- a/man/calculate_manifold_affinity_core.Rd
+++ b/man/calculate_manifold_affinity_core.Rd
@@ -7,7 +7,9 @@
 calculate_manifold_affinity_core(
   L_library_matrix,
   k_local_nn_for_sigma,
-  use_sparse_W_params = list()
+  use_sparse_W_params = list(),
+  distance_engine = c("euclidean", "ann_euclidean"),
+  ann_threshold = 10000
 )
 }
 \arguments{
@@ -22,6 +24,8 @@ bandwidth calculation (e.g., 7)}
 \item \code{sparse_if_N_gt}: Threshold for N to switch to sparse matrix (e.g., 5000)
 \item \code{k_nn_for_W_sparse}: Number of nearest neighbors to keep in sparse W
 }}
+\item{distance_engine}{Character string specifying the distance computation method. Options are \code{"euclidean"} for exact distances or \code{"ann_euclidean"} for approximate nearest neighbors via RcppHNSW. If \code{"ann_euclidean"} is requested but RcppHNSW is not installed, the function falls back to exact distances with a warning.}
+\item{ann_threshold}{Integer. When \code{distance_engine = "euclidean"} and the number of HRFs exceeds this threshold, the function will attempt to use RcppHNSW for approximate neighbors if available.}
 }
 \value{
 S_markov_matrix An N x N Markov transition matrix (regular or sparse
@@ -36,6 +40,10 @@ This function implements the affinity matrix construction from
 Component 0, Step 1 of the M-HRF-LSS pipeline. It uses the self-tuning
 local scaling method from Zelnik-Manor & Perona (2005) where each HRF's
 bandwidth sigma_i is set to its k-th nearest neighbor distance.
+The \code{distance_engine} argument controls whether exact or approximate
+nearest neighbor distances are used. When \code{"ann_euclidean"} is chosen but
+the \CRANpkg{RcppHNSW} package is unavailable, the function falls back to exact
+distances with a warning.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-manifold-construction.R
+++ b/tests/testthat/test-manifold-construction.R
@@ -217,3 +217,19 @@ test_that("get_manifold_basis_reconstructor_core reconstruction works", {
   expect_true(is.finite(B_norm))
   expect_lt(B_norm, 1000)  # Arbitrary but reasonable upper bound
 })
+
+test_that("ann_euclidean distance falls back when RcppHNSW missing", {
+  skip_if(requireNamespace("RcppHNSW", quietly = TRUE),
+          "RcppHNSW installed; cannot test fallback")
+  p <- 5
+  N <- 10
+  L_library <- matrix(rnorm(p * N), nrow = p, ncol = N)
+  expect_warning(
+    calculate_manifold_affinity_core(
+      L_library,
+      k_local_nn_for_sigma = 2,
+      distance_engine = "ann_euclidean"
+    ),
+    "RcppHNSW"
+  )
+})


### PR DESCRIPTION
## Summary
- warn and fall back if `RcppHNSW` is missing when `distance_engine = "ann_euclidean"`
- document new arguments `distance_engine` and `ann_threshold`
- add regression test for the fallback behavior

## Testing
- ❌ `R CMD check` *(fails: R is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683c80e14690832d8f1b4eaeb5a37fbc