### PR TITLE
Add validation for k_local_nn_for_sigma

### DIFF
--- a/R/core_manifold_construction.R
+++ b/R/core_manifold_construction.R
@@ -8,8 +8,8 @@
 #'
 #' @param L_library_matrix A p x N matrix of HRF shapes, where p is the number 
 #'   of time points and N is the number of HRFs in the library
-#' @param k_local_nn_for_sigma Integer, k-nearest neighbors for self-tuning 
-#'   bandwidth calculation (e.g., 7)
+#' @param k_local_nn_for_sigma Positive integer (< N), k-nearest neighbors for
+#'   self-tuning bandwidth calculation (e.g., 7)
 #' @param use_sparse_W_params List with optional parameters for sparse W matrix:
 #'   \itemize{
 #'     \item \code{sparse_if_N_gt}: Threshold for N to switch to sparse matrix (e.g., 5000)
@@ -56,7 +56,12 @@ calculate_manifold_affinity_core <- function(L_library_matrix,
   
   N <- ncol(L_library_matrix)
   p <- nrow(L_library_matrix)
-  
+
+  if (!is.numeric(k_local_nn_for_sigma) || length(k_local_nn_for_sigma) != 1 ||
+      k_local_nn_for_sigma < 1 || k_local_nn_for_sigma != round(k_local_nn_for_sigma)) {
+    stop("k_local_nn_for_sigma must be a positive integer")
+  }
+
   if (k_local_nn_for_sigma >= N) {
     stop("k_local_nn_for_sigma must be less than the number of HRFs (N)")
   }

--- a/man/calculate_manifold_affinity_core.Rd
+++ b/man/calculate_manifold_affinity_core.Rd
@@ -14,7 +14,7 @@ calculate_manifold_affinity_core(
 \item{L_library_matrix}{A p x N matrix of HRF shapes, where p is the number
 of time points and N is the number of HRFs in the library}
 
-\item{k_local_nn_for_sigma}{Integer, k-nearest neighbors for self-tuning
+\item{k_local_nn_for_sigma}{Positive integer (\< N), k-nearest neighbors for self-tuning
 bandwidth calculation (e.g., 7)}
 
 \item{use_sparse_W_params}{List with optional parameters for sparse W matrix:

--- a/tests/testthat/test-manifold-construction.R
+++ b/tests/testthat/test-manifold-construction.R
@@ -77,6 +77,17 @@ test_that("calculate_manifold_affinity_core validates inputs correctly", {
     calculate_manifold_affinity_core(L_small, 4),
     "k_local_nn_for_sigma must be less than the number of HRFs"
   )
+
+  # Test with non-positive or non-integer k
+  expect_error(
+    calculate_manifold_affinity_core(L_small, 0),
+    "k_local_nn_for_sigma must be a positive integer"
+  )
+
+  expect_error(
+    calculate_manifold_affinity_core(L_small, 2.5),
+    "k_local_nn_for_sigma must be a positive integer"
+  )
 })
 
 test_that("calculate_manifold_affinity_core produces symmetric affinities", {


### PR DESCRIPTION
## Summary
- validate `k_local_nn_for_sigma` in `calculate_manifold_affinity_core`
- document the new restriction
- test the new error conditions

## Testing
- `R -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c80e2f868832d9dec9fbd2ce2c6f1