### PR TITLE
Fix D_inv computation

### DIFF
--- a/R/core_manifold_construction.R
+++ b/R/core_manifold_construction.R
@@ -159,17 +159,14 @@ calculate_manifold_affinity_core <- function(L_library_matrix,
     }
   }
   
-  # Create D_inv (inverse degree matrix)
-  D_inv <- diag(1 / row_sums)
-  
   # Compute Markov matrix S
   if (inherits(W, "Matrix")) {
     # If W is sparse, keep S sparse
     D_inv <- Matrix::Diagonal(x = 1 / row_sums)
-    S_markov_matrix <- D_inv %*% W
   } else {
-    S_markov_matrix <- D_inv %*% W
+    D_inv <- diag(1 / row_sums)
   }
+  S_markov_matrix <- D_inv %*% W
   
   return(S_markov_matrix)
 }


### PR DESCRIPTION
## Summary
- compute the inverse degree matrix only once and only with the appropriate class

## Testing
- `R -q -e 'devtools::test()'` *(fails: `R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683c80e66290832d95dbd253122d15ae