### PR TITLE
Clamp k_nn_sparse and test edge case

### DIFF
--- a/R/core_manifold_construction.R
+++ b/R/core_manifold_construction.R
@@ -13,7 +13,8 @@
 #' @param use_sparse_W_params List with optional parameters for sparse W matrix:
 #'   \itemize{
 #'     \item \code{sparse_if_N_gt}: Threshold for N to switch to sparse matrix (e.g., 5000)
-#'     \item \code{k_nn_for_W_sparse}: Number of nearest neighbors to keep in sparse W
+#'     \item \code{k_nn_for_W_sparse}: Number of nearest neighbors to keep in sparse W. Must be less
+#'       than the number of HRFs (N); values \code{>= N} are truncated to \code{N - 1}.
 #'   }
 #' 
 #' @return S_markov_matrix An N x N Markov transition matrix (regular or sparse 
@@ -64,6 +65,12 @@ calculate_manifold_affinity_core <- function(L_library_matrix,
   # Extract parameters for sparse matrix handling
   sparse_threshold <- use_sparse_W_params$sparse_if_N_gt
   k_nn_sparse <- use_sparse_W_params$k_nn_for_W_sparse
+
+  if (!is.null(k_nn_sparse)) {
+    if (k_nn_sparse >= N) {
+      k_nn_sparse <- N - 1
+    }
+  }
   
   distance_engine <- match.arg(distance_engine)
 

--- a/tests/testthat/test-manifold-construction.R
+++ b/tests/testthat/test-manifold-construction.R
@@ -64,6 +64,32 @@ test_that("calculate_manifold_affinity_core handles sparse matrix parameters", {
   expect_equal(row_sums, rep(1, N), tolerance = 1e-10)
 })
 
+test_that("k_nn_for_W_sparse larger than N is truncated", {
+  set.seed(999)
+  p <- 5
+  N <- 10
+  L_library_matrix <- matrix(rnorm(p * N), nrow = p, ncol = N)
+
+  sparse_params <- list(
+    sparse_if_N_gt = 1,
+    k_nn_for_W_sparse = N + 5
+  )
+
+  S_markov <- calculate_manifold_affinity_core(
+    L_library_matrix,
+    k_local_nn_for_sigma = 2,
+    use_sparse_W_params = sparse_params
+  )
+
+  expect_equal(dim(S_markov), c(N, N))
+  if (inherits(S_markov, "Matrix")) {
+    row_sums <- Matrix::rowSums(S_markov)
+  } else {
+    row_sums <- rowSums(S_markov)
+  }
+  expect_equal(row_sums, rep(1, N), tolerance = 1e-10)
+})
+
 test_that("calculate_manifold_affinity_core validates inputs correctly", {
   # Test with non-matrix input
   expect_error(


### PR DESCRIPTION
## Summary
- enforce `k_nn_for_W_sparse < N` in `calculate_manifold_affinity_core`
- document new truncation rule
- test that overly large `k_nn_for_W_sparse` is handled

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c80e8a70c832dbb9dc25b6789610c