### PR TITLE
Fix eigendecomposition for non-symmetric matrices

### DIFF
--- a/R/core_manifold_construction.R
+++ b/R/core_manifold_construction.R
@@ -193,9 +193,13 @@ calculate_manifold_affinity_core <- function(L_library_matrix,
 #'   }
 #'   
 #' @details This function implements Component 0, Steps 3-5 of the M-HRF-LSS pipeline.
-#'   It computes the diffusion map embedding of the HRF library and creates a 
+#'   It computes the diffusion map embedding of the HRF library and creates a
 #'   reconstructor matrix that maps low-dimensional manifold coordinates back to
 #'   full HRF shapes.
+#'
+#'   For large libraries (N > 100) and when the \pkg{RSpectra} package is
+#'   available, the eigendecomposition is computed using
+#'   \code{RSpectra::eigs()}, which handles non-symmetric matrices efficiently.
 #'   
 #' @examples
 #' \dontrun{
@@ -240,14 +244,15 @@ get_manifold_basis_reconstructor_core <- function(S_markov_matrix,
   # Step 3: Compute diffusion map coordinates using eigendecomposition
   # We need top k eigenvectors, where k is larger than target to allow for selection
   k_eig_max <- min(N - 1, max(10, m_manifold_dim_target + 5))
-  
+  eig_k <- min(k_eig_max + 1, N - 1)  # ensure k < N to satisfy RSpectra requirements
+
   # Use RSpectra for efficient eigendecomposition of large matrices
   if (requireNamespace("RSpectra", quietly = TRUE) && N > 100) {
-    # For large matrices, use RSpectra
-    eig_result <- RSpectra::eigs_sym(
-      S_markov_matrix, 
-      k = k_eig_max + 1,  # +1 for the trivial eigenvector
-      which = "LM"  # Largest magnitude
+    # For large matrices, use RSpectra::eigs (handles non-symmetric matrices)
+    eig_result <- RSpectra::eigs(
+      S_markov_matrix,
+      k = eig_k,
+      which = "LM"
     )
     eigenvalues_full <- eig_result$values
     eigenvectors_full <- eig_result$vectors
@@ -257,9 +262,9 @@ get_manifold_basis_reconstructor_core <- function(S_markov_matrix,
       S_markov_matrix <- as.matrix(S_markov_matrix)
     }
     eig_result <- eigen(S_markov_matrix, symmetric = FALSE)
-    # Take only the top k_eig_max + 1 eigenvectors
-    eigenvalues_full <- eig_result$values[1:(k_eig_max + 1)]
-    eigenvectors_full <- eig_result$vectors[, 1:(k_eig_max + 1)]
+    # Take only the top eig_k eigenvectors
+    eigenvalues_full <- eig_result$values[1:eig_k]
+    eigenvectors_full <- eig_result$vectors[, 1:eig_k]
   }
   
   # The first eigenvector should be trivial (all ones for stochastic matrix)

--- a/man/get_manifold_basis_reconstructor_core.Rd
+++ b/man/get_manifold_basis_reconstructor_core.Rd
@@ -38,6 +38,9 @@ This function implements Component 0, Steps 3-5 of the M-HRF-LSS pipeline.
 It computes the diffusion map embedding of the HRF library and creates a
 reconstructor matrix that maps low-dimensional manifold coordinates back to
 full HRF shapes.
+For large libraries (N > 100) and when the \pkg{RSpectra} package is
+available, the eigendecomposition is computed using \code{RSpectra::eigs()},
+which efficiently handles non-symmetric matrices.
 }
 \examples{
 \dontrun{

--- a/repomix-output.xml
+++ b/repomix-output.xml
@@ -14606,14 +14606,15 @@ get_manifold_basis_reconstructor_core <- function(S_markov_matrix,
   # Step 3: Compute diffusion map coordinates using eigendecomposition
   # We need top k eigenvectors, where k is larger than target to allow for selection
   k_eig_max <- min(N - 1, max(10, m_manifold_dim_target + 5))
-  
+  eig_k <- min(k_eig_max + 1, N - 1)
+
   # Use RSpectra for efficient eigendecomposition of large matrices
   if (requireNamespace("RSpectra", quietly = TRUE) && N > 100) {
-    # For large matrices, use RSpectra
-    eig_result <- RSpectra::eigs_sym(
-      S_markov_matrix, 
-      k = k_eig_max + 1,  # +1 for the trivial eigenvector
-      which = "LM"  # Largest magnitude
+    # For large matrices, use RSpectra::eigs for non-symmetric matrices
+    eig_result <- RSpectra::eigs(
+      S_markov_matrix,
+      k = eig_k,
+      which = "LM"
     )
     eigenvalues_full <- eig_result$values
     eigenvectors_full <- eig_result$vectors
@@ -14623,9 +14624,9 @@ get_manifold_basis_reconstructor_core <- function(S_markov_matrix,
       S_markov_matrix <- as.matrix(S_markov_matrix)
     }
     eig_result <- eigen(S_markov_matrix, symmetric = FALSE)
-    # Take only the top k_eig_max + 1 eigenvectors
-    eigenvalues_full <- eig_result$values[1:(k_eig_max + 1)]
-    eigenvectors_full <- eig_result$vectors[, 1:(k_eig_max + 1)]
+    # Take only the top eig_k eigenvectors
+    eigenvalues_full <- eig_result$values[1:eig_k]
+    eigenvectors_full <- eig_result$vectors[, 1:eig_k]
   }
   
   # The first eigenvector should be trivial (all ones for stochastic matrix)

--- a/tests/testthat/test-manifold-construction.R
+++ b/tests/testthat/test-manifold-construction.R
@@ -217,3 +217,21 @@ test_that("get_manifold_basis_reconstructor_core reconstruction works", {
   expect_true(is.finite(B_norm))
   expect_lt(B_norm, 1000)  # Arbitrary but reasonable upper bound
 })
+
+test_that("get_manifold_basis_reconstructor_core handles large N with RSpectra", {
+  skip_if_not_installed("RSpectra")
+  set.seed(101)
+  p <- 30
+  N <- 250
+  L_library <- matrix(rnorm(p * N), nrow = p, ncol = N)
+  S <- calculate_manifold_affinity_core(L_library, k_local_nn_for_sigma = 7)
+
+  result <- get_manifold_basis_reconstructor_core(
+    S, L_library,
+    m_manifold_dim_target = 5,
+    m_manifold_dim_min_variance = 0.95
+  )
+
+  expect_equal(nrow(result$Phi_coords_matrix), N)
+  expect_true(ncol(result$Phi_coords_matrix) < N)
+})


### PR DESCRIPTION
## Summary
- use `RSpectra::eigs` instead of `eigs_sym`
- ensure eigenvector count remains below N
- document RSpectra usage
- test large `N` cases

## Testing
- `R -q -e 'print("hello")'` *(fails: `R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683c80f07e3c832d85c39ff6334072a8