### PR TITLE
Handle missing RcppHNSW in ann_euclidean search

### DIFF
--- a/man/make_voxel_graph_laplacian_core.Rd
+++ b/man/make_voxel_graph_laplacian_core.Rd
@@ -5,14 +5,31 @@
 \alias{make_voxel_graph_laplacian_core}
 \title{Construct Graph Laplacian for Voxel Coordinates (Core)}
 \usage{
-make_voxel_graph_laplacian_core(voxel_coords_matrix, num_neighbors_Lsp = 6)
+make_voxel_graph_laplacian_core(
+  voxel_coords_matrix,
+  num_neighbors_Lsp = 6,
+  distance_engine = c("euclidean", "ann_euclidean"),
+  ann_threshold = 10000
+)
 
-make_voxel_graph_laplacian_core(voxel_coords_matrix, num_neighbors_Lsp = 6)
+make_voxel_graph_laplacian_core(
+  voxel_coords_matrix,
+  num_neighbors_Lsp = 6,
+  distance_engine = c("euclidean", "ann_euclidean"),
+  ann_threshold = 10000
+)
 }
 \arguments{
 \item{voxel_coords_matrix}{V x 3 matrix of voxel coordinates}
 
 \item{num_neighbors_Lsp}{number of nearest neighbours}
+\item{distance_engine}{Choice of distance computation engine. "euclidean" uses
+exact search while "ann_euclidean" relies on approximate nearest neighbours via
+the \pkg{RcppHNSW} package. If the package is not installed, this option falls
+back to the exact search with a warning.}
+\item{ann_threshold}{When \code{distance_engine = "euclidean"}, datasets with a
+number of voxels larger than this threshold automatically use the approximate
+engine if \pkg{RcppHNSW} is available.}
 }
 \value{
 L_sp_sparse_matrix A V x V sparse Laplacian matrix (Matrix::sparseMatrix)
@@ -29,6 +46,9 @@ It constructs a k-nearest neighbor graph from voxel coordinates and computes
 the normalized graph Laplacian L = D - W, where W is the adjacency matrix
 and D is the degree matrix. The resulting Laplacian is used for spatial
 smoothing of manifold coordinates.
+If \code{distance_engine = "ann_euclidean"} is requested but the
+\pkg{RcppHNSW} package is not installed, the function falls back to the exact
+search and issues a warning.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-spatial-smoothing.R
+++ b/tests/testthat/test-spatial-smoothing.R
@@ -107,6 +107,28 @@ test_that("make_voxel_graph_laplacian_core handles edge cases", {
   expect_true(all(abs(Matrix::rowSums(L)) < 1e-10))
 })
 
+test_that("ann_euclidean falls back when RcppHNSW absent", {
+  coords <- matrix(runif(30), 10, 3)
+
+  if (!requireNamespace("RcppHNSW", quietly = TRUE)) {
+    expect_warning(
+      L_ann <- make_voxel_graph_laplacian_core(
+        coords, num_neighbors_Lsp = 3, distance_engine = "ann_euclidean"
+      ),
+      "falling back"
+    )
+    L_exact <- make_voxel_graph_laplacian_core(
+      coords, num_neighbors_Lsp = 3, distance_engine = "euclidean"
+    )
+    expect_equal(L_ann, L_exact)
+  } else {
+    L_ann <- make_voxel_graph_laplacian_core(
+      coords, num_neighbors_Lsp = 3, distance_engine = "ann_euclidean"
+    )
+    expect_true(inherits(L_ann, "Matrix"))
+  }
+})
+
 test_that("apply_spatial_smoothing_core works correctly", {
   # Create test data
   set.seed(123)


### PR DESCRIPTION
## Summary
- mention distance_engine option in docs
- warn and fall back to exact search when RcppHNSW is unavailable
- document fallback behaviour
- test ann_euclidean fallback logic

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_683c80febfb4832d81f44375cc14bdf5