### PR TITLE
Preserve sparsity in adjacency symmetrization

### DIFF
--- a/R/core_manifold_construction.R
+++ b/R/core_manifold_construction.R
@@ -85,7 +85,7 @@ calculate_manifold_affinity_core <- function(L_library_matrix,
       w_vec <- exp(-(d_vec^2) / sigma_prod_vec)
       W <- Matrix::sparseMatrix(i = i_vec, j = j_vec, x = w_vec,
                                 dims = c(N, N))
-      W <- pmax(W, Matrix::t(W))
+      W <- Matrix::pmax(W, Matrix::t(W))
     } else {
       W <- matrix(0, N, N)
       for (i in seq_len(N)) {
@@ -131,7 +131,7 @@ calculate_manifold_affinity_core <- function(L_library_matrix,
       W_sparse[i, !mask] <- 0
     }
     # Symmetrize the sparse matrix (take maximum of W_ij and W_ji)
-    W <- pmax(W_sparse, t(W_sparse))
+    W <- Matrix::pmax(W_sparse, Matrix::t(W_sparse))
     
     # Convert to sparse matrix format
     if (requireNamespace("Matrix", quietly = TRUE)) {

--- a/R/core_spatial_smoothing.R
+++ b/R/core_spatial_smoothing.R
@@ -101,7 +101,7 @@ make_voxel_graph_laplacian_core <- function(voxel_coords_matrix,
   
   # Make symmetric by taking max(W, W^T)
   # This ensures if i is a neighbor of j OR j is a neighbor of i, they're connected
-  W_symmetric <- pmax(W_directed, Matrix::t(W_directed))
+  W_symmetric <- Matrix::pmax(W_directed, Matrix::t(W_directed))
   
   # Step 3: Compute degree matrix D
   degrees <- Matrix::rowSums(W_symmetric)

--- a/tests/testthat/test-manifold-construction.R
+++ b/tests/testthat/test-manifold-construction.R
@@ -49,7 +49,7 @@ test_that("calculate_manifold_affinity_core handles sparse matrix parameters", {
   # Check if Matrix package is available
   if (requireNamespace("Matrix", quietly = TRUE)) {
     # Should return a sparse matrix
-    expect_true(inherits(S_markov_sparse, "Matrix"))
+    expect_true(inherits(S_markov_sparse, "sparseMatrix"))
   }
   
   # Check basic properties still hold

--- a/tests/testthat/test-spatial-smoothing.R
+++ b/tests/testthat/test-spatial-smoothing.R
@@ -13,7 +13,7 @@ test_that("make_voxel_graph_laplacian_core works for simple grid", {
   expect_equal(dim(L_sparse), c(9, 9))
   
   # Check that it's sparse
-  expect_true(inherits(L_sparse, "Matrix"))
+  expect_true(inherits(L_sparse, "sparseMatrix"))
   
   # Check Laplacian properties
   # Row sums should be zero (or very close due to numerical precision)
@@ -274,5 +274,13 @@ test_that("spatial smoothing integration test", {
   for (j in 1:m) {
     # Variance should be very small
     expect_lt(var(Xi_very_smooth[j, ]), 0.01)
+  }
+})
+
+test_that("symmetrization step retains sparse class", {
+  if (requireNamespace("Matrix", quietly = TRUE)) {
+    M <- Matrix::sparseMatrix(i = c(1, 2), j = c(2, 3), x = 1, dims = c(3, 3))
+    M_sym <- Matrix::pmax(M, Matrix::t(M))
+    expect_true(inherits(M_sym, "sparseMatrix"))
   }
 })


### PR DESCRIPTION
## Summary
- ensure symmetry operations on sparse matrices keep them sparse
- update tests to expect `sparseMatrix` class
- add regression test for `Matrix::pmax` sparse result

## Testing
- `R -q -e "sessionInfo()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c81028b38832d9e784cb77545f131