### PR TITLE
Improve QC metric computation

### DIFF
--- a/man/dot-compute_qc_metrics.Rd
+++ b/man/dot-compute_qc_metrics.Rd
@@ -4,7 +4,8 @@
 \alias{.compute_qc_metrics}
 \title{Compute QC metrics}
 \usage{
-.compute_qc_metrics(Y_data, hrf_shapes, amplitudes, manifold_coords, params)
+.compute_qc_metrics(Y_data, X_condition_list, hrf_shapes, amplitudes,
+  manifold_coords, params)
 }
 \description{
 Compute QC metrics


### PR DESCRIPTION
## Summary
- compute voxelwise R² using reconstructed design matrices in `.compute_qc_metrics`
- store per-voxel R² and mean value for diagnostics
- update call site and documentation

## Testing
- `R -e "sessionInfo()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c81210514832d930e77c481dc53e7