### PR TITLE
Enable adaptive smoothing to use local SNR

### DIFF
--- a/man/dot-run_spatial_smoothing.Rd
+++ b/man/dot-run_spatial_smoothing.Rd
@@ -4,7 +4,7 @@
 \alias{.run_spatial_smoothing}
 \title{Run spatial smoothing}
 \usage{
-.run_spatial_smoothing(Xi_matrix, voxel_coords, params, progress)
+.run_spatial_smoothing(Xi_matrix, voxel_coords, params, progress, Y_data = NULL)
 }
 \description{
 Run spatial smoothing


### PR DESCRIPTION
## Summary
- compute `local_snr` inside `.run_spatial_smoothing()`
- pass the vector to `apply_spatial_smoothing_adaptive()`
- expose the optional `Y_data` argument in documentation
- test adaptive smoothing uses different lambdas when SNR varies

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_683c812125e0832d932a5d9a17299b5d