### PR TITLE
Fix output directory handling and test

### DIFF
--- a/R/mhrf_lss.R
+++ b/R/mhrf_lss.R
@@ -37,7 +37,8 @@
 #' @param save_intermediate Logical; whether to save intermediate results for
 #'   debugging (default: FALSE)
 #' @param output_dir Directory for saving results and intermediate files
-#'   (default: temporary directory)
+#'   (default: temporary directory). If the directory does not exist, it will be
+#'   created automatically.
 #' @param ... Additional parameters to override preset values. See 
 #'   \code{\link{get_preset_params}} for available options.
 #'
@@ -162,6 +163,11 @@ mhrf_analyze <- function(Y_data,
   params$verbose_level <- verbose_level
   params$save_intermediate <- save_intermediate
   params$output_dir <- output_dir
+
+  # Ensure output directory exists before saving
+  if (!dir.exists(output_dir)) {
+    dir.create(output_dir, recursive = TRUE)
+  }
   
   # Add default values for parameters that might be missing
   params$p_hrf <- params$p_hrf %||% 25

--- a/man/mhrf_analyze.Rd
+++ b/man/mhrf_analyze.Rd
@@ -61,7 +61,8 @@ Set to -1 to use all available cores.}
 debugging (default: FALSE)}
 
 \item{output_dir}{Directory for saving results and intermediate files
-(default: temporary directory)}
+(default: temporary directory). If the directory does not exist, it will be
+created automatically.}
 
 \item{...}{Additional parameters to override preset values. See
 \code{\link{get_preset_params}} for available options.}

--- a/tests/testthat/test-output-dir.R
+++ b/tests/testthat/test-output-dir.R
@@ -1,0 +1,33 @@
+context("Output directory handling")
+
+# Test that output directory is created when missing
+
+test_that("mhrf_analyze creates missing output directory", {
+  set.seed(1)
+  n <- 20
+  V <- 5
+  Y_data <- matrix(rnorm(n * V), n, V)
+
+  events <- data.frame(
+    condition = "A",
+    onset = c(5, 10),
+    duration = 1
+  )
+
+  out_dir <- file.path(tempdir(), "mhrf_output_test")
+  if (dir.exists(out_dir)) unlink(out_dir, recursive = TRUE)
+  expect_false(dir.exists(out_dir))
+
+  result <- mhrf_analyze(
+    Y_data = Y_data,
+    events = events,
+    TR = 2,
+    save_intermediate = TRUE,
+    output_dir = out_dir,
+    verbose = 0
+  )
+
+  expect_s3_class(result, "mhrf_result")
+  expect_true(dir.exists(out_dir))
+  expect_true(file.exists(file.path(out_dir, "mhrf_result.rds")))
+})


### PR DESCRIPTION
## Summary
- ensure `mhrf_analyze()` creates `output_dir` when needed
- document new behavior in docs
- add regression test for output directory creation

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c812216d4832d91b9eed000ad0fcd