### PR TITLE
Fix n_jobs detection with invalid values

### DIFF
--- a/R/mhrf_lss.R
+++ b/R/mhrf_lss.R
@@ -486,11 +486,10 @@ mhrf_analyze <- function(Y_data,
 #' Determine number of jobs
 #' @keywords internal
 .determine_n_jobs <- function(n_jobs) {
-  if (n_jobs == -1) {
-    parallel::detectCores()
-  } else {
-    min(n_jobs, parallel::detectCores())
-  }
+  cores <- parallel::detectCores()
+  if (is.null(n_jobs) || n_jobs <= 0) return(1L)
+  if (n_jobs == -1) return(cores)
+  min(n_jobs, cores)
 }
 
 

--- a/tests/testthat/test-determine-n-jobs.R
+++ b/tests/testthat/test-determine-n-jobs.R
@@ -1,0 +1,5 @@
+test_that(".determine_n_jobs handles invalid inputs", {
+  expect_equal(manifoldhrf:::`.determine_n_jobs`(NULL), 1L)
+  expect_equal(manifoldhrf:::`.determine_n_jobs`(0), 1L)
+  expect_equal(manifoldhrf:::`.determine_n_jobs`(-5), 1L)
+})


### PR DESCRIPTION
## Summary
- handle NULL or non-positive `n_jobs` in `.determine_n_jobs`
- add regression tests for `.determine_n_jobs`

## Testing
- `R -q -e "library(testthat); testthat::test_dir('tests/testthat')"` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683c81231e1c832dafc2fbb9aa8aa8af