### PR TITLE
Replace internal fmrireg call for level tokens

### DIFF
--- a/R/fmrireg_helpers.R
+++ b/R/fmrireg_helpers.R
@@ -36,3 +36,14 @@ HRF_RAW_EVENT_BASIS <- function(p_length, TR_sample, name = NULL) {
   fmrireg::as_hrf(basis_fun, name = hrf_name, nbasis = nbasis, span = span,
                   params = list(p_length = p_length, TR_sample = TR_sample))
 }
+
+#' Create a token for a factor level following fmrireg conventions
+#'
+#' @param factor_name Name of the factor variable
+#' @param level Level value
+#'
+#' @return Character string combining the factor name and level
+#' @keywords internal
+private_level_token <- function(factor_name, level) {
+  paste0(make.names(factor_name), ".", make.names(level))
+}

--- a/R/mhrf_lss.R
+++ b/R/mhrf_lss.R
@@ -534,7 +534,7 @@ mhrf_analyze <- function(Y_data,
   term_tag <- names(ev_model$terms)[1]
   X_condition_list <- vector("list", n_conditions)
   for (i in seq_along(conditions)) {
-    token <- fmrireg:::level_token("condition", conditions[i])
+    token <- private_level_token("condition", conditions[i])
     prefix <- paste0(term_tag, "_", token)
     cols <- grep(paste0("^", prefix, "_b"), colnames(X_full))
     X_condition_list[[i]] <- X_full[, cols, drop = FALSE]


### PR DESCRIPTION
## Summary
- implement `private_level_token()` to mimic `fmrireg:::level_token`
- use the new helper in `.create_design_matrices()`

## Testing
- `R -q -e "devtools::test()"` *(fails: `R` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c812532b8832dbfb3509fef9b7812