### PR TITLE
Implement unified lambda validation

### DIFF
--- a/R/core_alternating_optimization.R
+++ b/R/core_alternating_optimization.R
@@ -103,10 +103,8 @@ estimate_final_condition_betas_core <- function(Y_proj_matrix,
     stop("H_shapes_allvox_matrix must have V columns to match Y_proj_matrix")
   }
   
-  if (!is.numeric(lambda_beta_final) || length(lambda_beta_final) != 1 || 
-      lambda_beta_final < 0) {
-    stop("lambda_beta_final must be a non-negative scalar")
-  }
+  lambda_beta_final <- .validate_and_standardize_lambda(lambda_beta_final,
+                                                        "lambda_beta_final")
   
   # Validate control parameters
   if (!is.list(control_alt_list)) {

--- a/R/core_lss.R
+++ b/R/core_lss.R
@@ -91,10 +91,8 @@ prepare_lss_fixed_components_core <- function(A_lss_fixed_matrix,
     }
   }
   
-  if (!is.numeric(lambda_ridge_Alss) || length(lambda_ridge_Alss) != 1 || 
-      lambda_ridge_Alss < 0) {
-    stop("lambda_ridge_Alss must be a non-negative scalar")
-  }
+  lambda_ridge_Alss <- .validate_and_standardize_lambda(lambda_ridge_Alss,
+                                                        "lambda_ridge_Alss")
   
   # Step 1: Compute A'A
   AtA <- crossprod(A_lss_fixed_matrix)  # q_lss x q_lss

--- a/R/core_voxelwise_fit.R
+++ b/R/core_voxelwise_fit.R
@@ -258,9 +258,7 @@ solve_glm_for_gamma_core <- function(Z_list_of_matrices,
     stop("Y_proj_matrix must be a matrix")
   }
   
-  if (!is.numeric(lambda_gamma) || length(lambda_gamma) != 1 || lambda_gamma < 0) {
-    stop("lambda_gamma must be a non-negative scalar")
-  }
+  lambda_gamma <- .validate_and_standardize_lambda(lambda_gamma, "lambda_gamma")
   
   if (!is.logical(orthogonal_approx_flag) || length(orthogonal_approx_flag) != 1) {
     stop("orthogonal_approx_flag must be a single logical value")

--- a/R/input_validation.R
+++ b/R/input_validation.R
@@ -297,17 +297,7 @@
   # Validate common user parameters
   if ("lambda_gamma" %in% names(user_params)) {
     lambda_gamma <- user_params$lambda_gamma
-    if (!is.numeric(lambda_gamma) || lambda_gamma < 0) {
-      stop(
-        "lambda_gamma must be a non-negative number\n",
-        "  Received: ", lambda_gamma, "\n",
-        "  Hint: Use values between 0.001 and 0.1",
-        call. = FALSE
-      )
-    }
-    if (lambda_gamma > 1) {
-      warning("lambda_gamma is very large: ", lambda_gamma, ". This may cause over-regularization.")
-    }
+    lambda_gamma <- .validate_and_standardize_lambda(lambda_gamma, "lambda_gamma")
   }
   
   if ("m_manifold_dim_target" %in% names(user_params)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -41,3 +41,28 @@
     lapply(X, FUN)
   }
 }
+
+#' Validate and standardize ridge penalty parameter
+#'
+#' Ensures a lambda parameter is a non-negative scalar and applies
+#' consistent tolerance-based adjustments. Small values below a fixed
+#' threshold are coerced to zero with a warning. Unusually large values
+#' trigger a warning about potential over-regularization.
+#'
+#' @param lambda Numeric value provided by the user.
+#' @param name Character name of the parameter (for error messages).
+#' @return Sanitized lambda value.
+#' @keywords internal
+.validate_and_standardize_lambda <- function(lambda, name) {
+  tol <- 1e-8
+  if (!is.numeric(lambda) || length(lambda) != 1 || is.na(lambda) || lambda < 0) {
+    stop(sprintf("%s must be a non-negative scalar", name))
+  }
+  if (lambda < tol && lambda > 0) {
+    warning(sprintf("%s is near zero (%.2e); treating as 0", name, lambda))
+    lambda <- 0
+  } else if (lambda > 1) {
+    warning(sprintf("%s is large (%.2e); may cause over-regularization", name, lambda))
+  }
+  lambda
+}


### PR DESCRIPTION
## Summary
- centralize ridge penalty checks in `.validate_and_standardize_lambda`
- use new validator for `lambda_gamma`, `lambda_beta_final` and `lambda_ridge_Alss`
- validate user-provided `lambda_gamma` via new helper

## Testing
- `R CMD build .` *(fails: `R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683c84d4d454832d9e3c56e43eb7b333