### PR TITLE
Improve LSS RAM safety

### DIFF
--- a/R/core_lss.R
+++ b/R/core_lss.R
@@ -540,12 +540,11 @@ run_lss_voxel_loop_core <- function(Y_proj_matrix,
     return(Beta_trial_allvox_matrix)
   }
   
-  # Memory heuristic: Check if we can precompute all R_t matrices
-  # Each R_t is n x V, we have T of them
-  # Memory in bytes: T * n * V * 8 (assuming double precision)
-  estimated_memory_GB <- (T_trials * n * V * 8) / (1024^3)
-  
-  precompute_R_t <- (estimated_memory_GB < ram_heuristic_GB_for_Rt)
+  # Memory heuristic: check if we can precompute all R_t matrices.
+  # The helper estimates memory as T * V * 8 / 1e9 GB.
+  precompute_R_t <- check_ram_feasibility(
+    T_trials, V, ram_heuristic_GB_for_Rt
+  )
   
   if (precompute_R_t) {
     # Precompute all R_t matrices for efficiency

--- a/R/utils.R
+++ b/R/utils.R
@@ -41,3 +41,26 @@
     lapply(X, FUN)
   }
 }
+
+#' Check RAM feasibility for trial precomputation
+#'
+#' Estimates expected memory usage for storing trial-by-voxel matrices and
+#' compares it to a user-provided limit.
+#'
+#' @param T_trials Number of trials.
+#' @param V Number of voxels.
+#' @param ram_limit_GB Memory limit in gigabytes.
+#'
+#' @return Logical indicating whether precomputation is feasible.
+#' @keywords internal
+check_ram_feasibility <- function(T_trials, V, ram_limit_GB) {
+  expected_GB <- (T_trials * V * 8) / 1e9
+  feasible <- expected_GB < ram_limit_GB
+  if (!feasible) {
+    message(sprintf(
+      "Estimated memory %.2f GB exceeds limit %.2f GB - using lazy evaluation for trial regressors.",
+      expected_GB, ram_limit_GB
+    ))
+  }
+  feasible
+}

--- a/tests/testthat/test-lss.R
+++ b/tests/testthat/test-lss.R
@@ -499,3 +499,8 @@ test_that("LSS integration test with known signal", {
   # At least one voxel should show some correlation
   expect_gt(max(cors_active), 0.3)
 })
+test_that("check_ram_feasibility enforces RAM limit", {
+  expect_true(manifoldhrf:::check_ram_feasibility(5, 10, 1))
+  expect_false(manifoldhrf:::check_ram_feasibility(1000, 1000, 0.0001))
+  expect_message(manifoldhrf:::check_ram_feasibility(1000, 1000, 0.0001), "exceeds limit")
+})


### PR DESCRIPTION
## Summary
- add `check_ram_feasibility` helper for LSS trial precomputation
- enforce RAM heuristic via `check_ram_feasibility` in `run_lss_voxel_loop_core`
- test new RAM check helper

## Testing
- `devtools::test()` *(fails: `R` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683c84ea9f70832dae845d29d3b16872