### PR TITLE
Add shared input validation helpers and error logging

### DIFF
--- a/R/core_lss.R
+++ b/R/core_lss.R
@@ -456,25 +456,19 @@ run_lss_voxel_loop_core <- function(Y_proj_matrix,
   n <- nrow(Y_proj_matrix)
   V <- ncol(Y_proj_matrix)
   
-  if (!is.list(X_trial_onset_list_of_matrices)) {
-    stop("X_trial_onset_list_of_matrices must be a list")
-  }
-  
-  T_trials <- length(X_trial_onset_list_of_matrices)
-  
-  if (T_trials < 1) {
-    stop("X_trial_onset_list_of_matrices must contain at least one trial")
-  }
-  
-  if (!is.matrix(H_shapes_allvox_matrix)) {
-    stop("H_shapes_allvox_matrix must be a matrix")
-  }
-  
+  design_info <- validate_design_matrix_list(
+    X_trial_onset_list_of_matrices,
+    n_timepoints = n
+  )
+  T_trials <- design_info$k
+
+  validate_hrf_shape_matrix(
+    H_shapes_allvox_matrix,
+    n_timepoints = design_info$p,
+    n_voxels = V
+  )
+
   p <- nrow(H_shapes_allvox_matrix)
-  
-  if (ncol(H_shapes_allvox_matrix) != V) {
-    stop("H_shapes_allvox_matrix must have V columns to match Y_proj_matrix")
-  }
   
   if (!is.matrix(A_lss_fixed_matrix)) {
     stop("A_lss_fixed_matrix must be a matrix")

--- a/R/core_voxelwise_fit.R
+++ b/R/core_voxelwise_fit.R
@@ -50,26 +50,14 @@ project_out_confounds_core <- function(Y_data_matrix,
   if (!is.matrix(Y_data_matrix)) {
     stop("Y_data_matrix must be a matrix")
   }
-  
-  if (!is.list(X_list_of_matrices)) {
-    stop("X_list_of_matrices must be a list")
-  }
-  
-  n <- nrow(Y_data_matrix)
 
   if (anyNA(Y_data_matrix)) {
     stop("Y_data_matrix must not contain NA values")
   }
-  
-  # Check that all X matrices have the same number of rows as Y
-  for (i in seq_along(X_list_of_matrices)) {
-    if (!is.matrix(X_list_of_matrices[[i]])) {
-      stop(sprintf("X_list_of_matrices[[%d]] must be a matrix", i))
-    }
-    if (nrow(X_list_of_matrices[[i]]) != n) {
-      stop(sprintf("X_list_of_matrices[[%d]] must have %d rows to match Y_data_matrix", i, n))
-    }
-  }
+
+  n <- nrow(Y_data_matrix)
+
+  validate_design_matrix_list(X_list_of_matrices, n_timepoints = n)
   
   # If no confounds, return original matrices
   if (is.null(Z_confounds_matrix)) {
@@ -80,17 +68,7 @@ project_out_confounds_core <- function(Y_data_matrix,
   }
   
   # Validate confounds matrix
-  if (!is.matrix(Z_confounds_matrix)) {
-    stop("Z_confounds_matrix must be a matrix or NULL")
-  }
-
-  if (anyNA(Z_confounds_matrix)) {
-    stop("Z_confounds_matrix must not contain NA values")
-  }
-  
-  if (nrow(Z_confounds_matrix) != n) {
-    stop("Z_confounds_matrix must have the same number of rows as Y_data_matrix")
-  }
+  validate_confounds_matrix(Z_confounds_matrix, n_timepoints = n)
   
   # Check for rank deficiency in confounds
   if (ncol(Z_confounds_matrix) >= n) {

--- a/R/input_validation.R
+++ b/R/input_validation.R
@@ -462,3 +462,117 @@
     estimated_time_minutes = if (n_voxels > 10000) n_voxels / 1000 else 1
   ))
 }
+
+
+#' Validate a list of design matrices
+#'
+#' Ensures that each design matrix is numeric with consistent dimensions and
+#' aligned with the expected number of timepoints.
+#'
+#' @param X_list List of design matrices
+#' @param n_timepoints Expected number of rows for each matrix (optional)
+#' @return List with dimension information
+#' @keywords internal
+validate_design_matrix_list <- function(X_list, n_timepoints = NULL) {
+  if (!is.list(X_list) || length(X_list) == 0) {
+    stop("Design matrices must be provided as a non-empty list", call. = FALSE)
+  }
+
+  for (i in seq_along(X_list)) {
+    X <- X_list[[i]]
+    if (!is.matrix(X) || !is.numeric(X)) {
+      stop(sprintf("Design matrix %d must be a numeric matrix", i), call. = FALSE)
+    }
+    if (!is.null(n_timepoints) && nrow(X) != n_timepoints) {
+      stop(sprintf(
+        "Design matrix %d has %d rows but expected %d",
+        i, nrow(X), n_timepoints
+      ), call. = FALSE)
+    }
+    if (any(!is.finite(X))) {
+      stop(sprintf("Design matrix %d contains non-finite values", i), call. = FALSE)
+    }
+  }
+
+  p <- ncol(X_list[[1]])
+  if (any(sapply(X_list, ncol) != p)) {
+    stop("All design matrices must have the same number of columns", call. = FALSE)
+  }
+
+  list(
+    n_timepoints = if (is.null(n_timepoints)) nrow(X_list[[1]]) else n_timepoints,
+    p = p,
+    k = length(X_list)
+  )
+}
+
+
+#' Validate HRF shape matrix
+#'
+#' Checks that the HRF shape matrix has numeric type and expected dimensions.
+#'
+#' @param H_matrix HRF shape matrix
+#' @param n_timepoints Expected number of rows (optional)
+#' @param n_voxels Expected number of columns (optional)
+#' @return TRUE if validation passes
+#' @keywords internal
+validate_hrf_shape_matrix <- function(H_matrix,
+                                     n_timepoints = NULL,
+                                     n_voxels = NULL) {
+  if (!is.matrix(H_matrix) || !is.numeric(H_matrix)) {
+    stop("HRF shape matrix must be a numeric matrix", call. = FALSE)
+  }
+
+  if (!is.null(n_timepoints) && nrow(H_matrix) != n_timepoints) {
+    stop(sprintf(
+      "HRF shape matrix must have %d rows, not %d",
+      n_timepoints, nrow(H_matrix)
+    ), call. = FALSE)
+  }
+
+  if (!is.null(n_voxels) && ncol(H_matrix) != n_voxels) {
+    stop(sprintf(
+      "HRF shape matrix must have %d columns, not %d",
+      n_voxels, ncol(H_matrix)
+    ), call. = FALSE)
+  }
+
+  if (any(!is.finite(H_matrix))) {
+    stop("HRF shape matrix contains non-finite values", call. = FALSE)
+  }
+
+  TRUE
+}
+
+
+#' Validate confounds matrix
+#'
+#' Ensures the confounds matrix is numeric, properly dimensioned and free of NA
+#' values. A NULL input is also accepted.
+#'
+#' @param Z_matrix Confounds matrix or NULL
+#' @param n_timepoints Expected number of rows if not NULL
+#' @return TRUE if validation passes or matrix is NULL
+#' @keywords internal
+validate_confounds_matrix <- function(Z_matrix, n_timepoints) {
+  if (is.null(Z_matrix)) {
+    return(TRUE)
+  }
+
+  if (!is.matrix(Z_matrix) || !is.numeric(Z_matrix)) {
+    stop("confounds matrix must be a numeric matrix or NULL", call. = FALSE)
+  }
+
+  if (nrow(Z_matrix) != n_timepoints) {
+    stop(sprintf(
+      "confounds matrix must have %d rows to match data",
+      n_timepoints
+    ), call. = FALSE)
+  }
+
+  if (any(!is.finite(Z_matrix))) {
+    stop("confounds matrix contains non-finite values", call. = FALSE)
+  }
+
+  TRUE
+}

--- a/R/mhrf_lss.R
+++ b/R/mhrf_lss.R
@@ -235,7 +235,7 @@ mhrf_analyze <- function(Y_data,
   
   # Step 6: Run core M-HRF-LSS pipeline
   progress$update("Running M-HRF-LSS pipeline...")
-  
+
   # Component 0: HRF Manifold Construction
   progress$update("  Component 0: Constructing HRF manifold...", level = 2)
   
@@ -244,17 +244,24 @@ mhrf_analyze <- function(Y_data,
     params = params,
     progress = progress
   )
+
+  error_log <- list()
   
   # Component 1: Voxel-wise HRF Estimation
   progress$update("  Component 1: Estimating voxel-wise HRFs...", level = 2)
   
-  voxelwise_result <- .run_voxelwise_estimation(
-    Y_data = Y_matrix,
-    X_condition_list = X_condition_list,
-    manifold = manifold_result,
-    params = params,
-    progress = progress
-  )
+  voxelwise_result <- tryCatch({
+    .run_voxelwise_estimation(
+      Y_data = Y_matrix,
+      X_condition_list = X_condition_list,
+      manifold = manifold_result,
+      params = params,
+      progress = progress
+    )
+  }, error = function(e) {
+    error_log$component1 <<- e$message
+    stop(e)
+  })
   
   # Component 2: Spatial Smoothing
   progress$update("  Component 2: Applying spatial smoothing...", level = 2)
@@ -270,10 +277,15 @@ mhrf_analyze <- function(Y_data,
   # Component 3: HRF Reconstruction
   progress$update("  Component 3: Reconstructing HRF shapes...", level = 2)
   
-  hrf_shapes <- reconstruct_hrf_shapes_core(
-    B_reconstructor_matrix = manifold_result$B_reconstructor,
-    Xi_smoothed_matrix = smoothing_result$Xi_smooth
-  )
+  hrf_shapes <- tryCatch({
+    reconstruct_hrf_shapes_core(
+      B_reconstructor_matrix = manifold_result$B_reconstructor,
+      Xi_smoothed_matrix = smoothing_result$Xi_smooth
+    )
+  }, error = function(e) {
+    error_log$component3 <<- e$message
+    stop(e)
+  })
   
   # Apply physiological constraints if requested
   if (params$apply_hrf_constraints) {
@@ -309,7 +321,8 @@ mhrf_analyze <- function(Y_data,
     hrf_shapes = hrf_shapes,
     amplitudes = voxelwise_result$Beta_ident,
     manifold_coords = smoothing_result$Xi_smooth,
-    params = params
+    params = params,
+    error_log = error_log
   )
   
   # Step 8: Package results
@@ -807,11 +820,16 @@ mhrf_analyze <- function(Y_data,
 
 #' Run trial estimation
 #' @keywords internal
-.run_trial_estimation <- function(Y_data, X_trial_list, hrf_shapes, 
+.run_trial_estimation <- function(Y_data, X_trial_list, hrf_shapes,
                                  params, progress) {
-  
+
   n_voxels <- ncol(Y_data)
   n_trials <- length(X_trial_list)
+
+  validate_design_matrix_list(X_trial_list, n_timepoints = nrow(Y_data))
+  validate_hrf_shape_matrix(hrf_shapes,
+                            n_timepoints = ncol(X_trial_list[[1]]),
+                            n_voxels = n_voxels)
   
   # Initialize storage
   trial_amplitudes <- matrix(NA, n_trials, n_voxels)
@@ -902,7 +920,7 @@ mhrf_analyze <- function(Y_data,
 #' @param params List of pipeline parameters
 #' @keywords internal
 .compute_qc_metrics <- function(Y_data, X_condition_list, hrf_shapes, amplitudes,
-                               manifold_coords, params) {
+                               manifold_coords, params, error_log = NULL) {
   
   # Basic metrics
   qc <- list(
@@ -951,7 +969,11 @@ mhrf_analyze <- function(Y_data,
   qc$r_squared_voxels <- r2_voxels
   qc$diagnostics <- list(r2_voxelwise = r2_voxels)
   qc$quality_flags <- create_qc_flags(qc)
-  
+
+  if (!is.null(error_log)) {
+    qc$error_log <- error_log
+  }
+
   return(qc)
 }
 


### PR DESCRIPTION
## Summary
- implement `validate_design_matrix_list`, `validate_hrf_shape_matrix` and `validate_confounds_matrix`
- apply new helpers in `project_out_confounds_core` and LSS functions
- propagate component errors using `tryCatch` and record in QC metrics
- update QC metrics to store error log

## Testing
- `R CMD INSTALL .` *(fails: `R` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c851b0db8832da927c0624034aafe