### PR TITLE
Refactor LSS voxel loop API

### DIFF
--- a/R/mhrf_lss_interface.R
+++ b/R/mhrf_lss_interface.R
@@ -519,9 +519,8 @@ run_mhrf_lss_standard <- function(Y_data, design_info, manifold, Z_confounds,
       X_trial_onset_list_of_matrices = design_info$X_trial_list,
       H_shapes_allvox_matrix = H_shapes,
       A_lss_fixed_matrix = Z_confounds,
-      P_lss_matrix = lss_prep$P_lss_matrix,
-      p_lss_vector = lss_prep$p_lss_vector,
-      ram_heuristic_GB_for_Rt = 1.0
+      lambda_ridge = params$lambda_ridge_Alss %||% 1e-6,
+      n_jobs = params$n_jobs %||% 1
     )
   }
   

--- a/R/validation_simulation.R
+++ b/R/validation_simulation.R
@@ -730,9 +730,8 @@ run_pipeline_on_simulated_data <- function(bold_data, design_info, ground_truth_
     X_trial_onset_list_of_matrices = design_info$X_trial_list,
     H_shapes_allvox_matrix = H_shapes,
     A_lss_fixed_matrix = bold_data$Z_confounds,
-    P_lss_matrix = lss_prep$P_lss_matrix,
-    p_lss_vector = lss_prep$p_lss_vector,
-    ram_heuristic_GB_for_Rt = 1.0
+    lambda_ridge = pipeline_params$lambda_ridge_Alss,
+    n_jobs = pipeline_params$n_jobs %||% 1
   )
   
   # Step 5: Component 4 - Final condition betas


### PR DESCRIPTION
## Summary
- streamline `run_lss_voxel_loop_core` to use `run_lss_for_voxel_corrected_full`
- pass lambda and n_jobs and drop unused parameters
- update interface helpers to use the simplified API

## Testing
- `R CMD build` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683c8c2a7728832da78304c692865e20