### PR TITLE
Implement dataset simulation helper

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -55,6 +55,7 @@ export(run_lss_for_voxel_corrected_full)
 export(run_lss_woodbury_corrected)
 # run_lss_for_voxel_core and run_lss_voxel_loop_core are deprecated and no longer exported
 export(run_mhrf_lss_simulation)
+export(simulate_mhrf_dataset)
 export(run_with_fallback_cascade)
 export(screen_voxels)
 export(smart_initialize)

--- a/R/simulate_dataset.R
+++ b/R/simulate_dataset.R
@@ -1,0 +1,104 @@
+#' Simulate a Simple fMRI Dataset
+#'
+#' Generates synthetic BOLD data and accompanying design information
+#' using the internal simulation helpers. The output is wrapped in a
+#' `fmrireg::matrix_dataset` object so it can be used directly with
+#' functions that expect `fmrireg` datasets.
+#'
+#' @param n_voxels Number of voxels to simulate.
+#' @param n_timepoints Number of time points.
+#' @param n_trials Number of trials per condition.
+#' @param n_conditions Number of experimental conditions.
+#' @param TR Repetition time in seconds.
+#' @param hrf_variability HRF variability level: "none", "moderate", or "high".
+#' @param noise_level DVARS noise level as percentage.
+#' @param seed Random seed for reproducibility.
+#'
+#' @return A list containing:
+#'   \itemize{
+#'     \item \code{dataset}: `fmrireg` matrix_dataset with the simulated BOLD data
+#'     \item \code{bold_data}: Matrix of noisy BOLD signals (time x voxel)
+#'     \item \code{confounds}: Matrix of confound regressors
+#'     \item \code{ground_truth}: List with HRFs, amplitudes and design info
+#'   }
+#'
+#' @examples
+#' \dontrun{
+#' sim <- simulate_mhrf_dataset(n_voxels = 50, n_timepoints = 150)
+#' }
+#'
+#' @export
+simulate_mhrf_dataset <- function(n_voxels = 50,
+                                  n_timepoints = 150,
+                                  n_trials = 10,
+                                  n_conditions = 2,
+                                  TR = 1.0,
+                                  hrf_variability = c("none", "moderate", "high"),
+                                  noise_level = 5,
+                                  seed = 1) {
+
+  set.seed(seed)
+  hrf_variability <- match.arg(hrf_variability)
+
+  # Ground truth HRFs
+  hrfs <- generate_ground_truth_hrfs(
+    n_voxels = n_voxels,
+    hrf_variability = hrf_variability,
+    TR = TR,
+    manifold_params = list(TR_precision = 0.1)
+  )
+
+  # Experimental design
+  design <- generate_experimental_design(
+    n_timepoints = n_timepoints,
+    n_trials = n_trials,
+    n_conditions = n_conditions,
+    TR = TR,
+    hrf_length = length(hrfs$time_points)
+  )
+
+  # Amplitudes
+  amps <- generate_ground_truth_amplitudes(
+    n_voxels = n_voxels,
+    n_conditions = n_conditions,
+    n_trials = design$total_trials,
+    activation_patterns = c("sustained", "transient", "mixed")
+  )
+
+  # BOLD data with noise
+  bold <- generate_bold_data(
+    ground_truth_hrfs = hrfs,
+    ground_truth_amplitudes = amps,
+    design_info = design,
+    noise_level = noise_level,
+    TR = TR
+  )
+
+  # Event table for fmrireg dataset
+  event_table <- data.frame(
+    onset = design$onsets,
+    duration = 0,
+    amplitude = 1,
+    condition = factor(design$conditions),
+    trial = seq_along(design$onsets),
+    run = 1
+  )
+
+  dset <- fmrireg::matrix_dataset(
+    datamat = bold$Y_data,
+    TR = TR,
+    run_length = n_timepoints,
+    event_table = event_table
+  )
+
+  list(
+    dataset = dset,
+    bold_data = bold$Y_data,
+    confounds = bold$Z_confounds,
+    ground_truth = list(
+      hrfs = hrfs,
+      amplitudes = amps,
+      design = design
+    )
+  )
+}

--- a/tests/testthat/test-simulate-dataset.R
+++ b/tests/testthat/test-simulate-dataset.R
@@ -1,0 +1,21 @@
+context("simulate_mhrf_dataset")
+
+test_that("simulate_mhrf_dataset creates valid dataset", {
+  set.seed(123)
+  sim <- simulate_mhrf_dataset(
+    n_voxels = 20,
+    n_timepoints = 80,
+    n_trials = 5,
+    n_conditions = 2,
+    TR = 1.5,
+    hrf_variability = "moderate",
+    noise_level = 5
+  )
+
+  expect_type(sim, "list")
+  expect_true("dataset" %in% names(sim))
+  expect_true(nrow(sim$bold_data) == 80)
+  expect_true(ncol(sim$bold_data) == 20)
+  expect_s3_class(sim$dataset, "matrix_dataset")
+})
+


### PR DESCRIPTION
## Summary
- add `simulate_mhrf_dataset` to create simple synthetic datasets
- export the helper in NAMESPACE
- test dataset generation

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c901176f8832d9d01f3b8d0590ed2