### PR TITLE
Add core validation and fallback tests

### DIFF
--- a/tests/testthat/test-fallback-cascade.R
+++ b/tests/testthat/test-fallback-cascade.R
@@ -1,0 +1,12 @@
+context("fallback cascade")
+
+ test_that("run_with_fallback_cascade falls back when manifold fails", {
+  set.seed(1)
+  Y <- matrix(rnorm(20), 5, 4)
+  X <- list(matrix(rnorm(5), 5, 1))
+  params <- list(TR = 1, m_manifold_dim = -2)
+  result <- run_with_fallback_cascade(Y, X, params)
+  expect_true(result$success)
+  expect_true(all(result$method == "pca"))
+  expect_true(is.matrix(result$results$Beta))
+ })

--- a/tests/testthat/test-input-validation-core.R
+++ b/tests/testthat/test-input-validation-core.R
@@ -1,0 +1,24 @@
+context("input validation core")
+
+ test_that(".validate_Y_data rejects invalid input", {
+  expect_error(manifoldhrf:::`.validate_Y_data`("bad"), "matrix or NeuroVec")
+ })
+
+ test_that(".validate_events detects missing columns", {
+  events <- data.frame(onset = 1:5)
+  expect_error(manifoldhrf:::`.validate_events`(events, n_timepoints = 10, TR = 1),
+               "missing required columns")
+ })
+
+ test_that(".validate_voxel_mask checks length", {
+  mask <- c(TRUE, FALSE)
+  expect_error(manifoldhrf:::`.validate_voxel_mask`(mask, n_voxels = 5),
+               "length")
+ })
+
+ test_that(".validate_parameters validates TR and preset", {
+  expect_error(manifoldhrf:::`.validate_parameters`(TR = -1, preset = "balanced", n_voxels = 10),
+               "TR value seems unrealistic")
+  expect_error(manifoldhrf:::`.validate_parameters`(TR = 2, preset = "unknown", n_voxels = 10),
+               "Invalid preset")
+ })

--- a/tests/testthat/test-parallel-utils.R
+++ b/tests/testthat/test-parallel-utils.R
@@ -1,0 +1,17 @@
+context("parallel utilities")
+
+fun <- function(x) x * x
+
+ test_that(".parallel_lapply works sequentially and in parallel", {
+  X <- 1:5
+  res_seq <- manifoldhrf:::`.parallel_lapply`(X, fun, n_jobs = 1)
+  res_par <- manifoldhrf:::`.parallel_lapply`(X, fun, n_jobs = 2)
+  expect_equal(res_seq, res_par)
+})
+
+ test_that(".parallel_lapply handles single core gracefully", {
+  X <- 1:3
+  res0 <- manifoldhrf:::`.parallel_lapply`(X, fun, n_jobs = 1)
+  res1 <- manifoldhrf:::`.parallel_lapply`(X, fun, n_jobs = 1)
+  expect_equal(res0, res1)
+})


### PR DESCRIPTION
## Summary
- add `.parallel_lapply` tests
- cover input validation helpers
- ensure `run_with_fallback_cascade` fallback logic works

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683c959837a4832d87eb37100d47de45