### PR TITLE
Add tests for missing core functions

### DIFF
--- a/tests/testthat/test-lss-loop-core.R
+++ b/tests/testthat/test-lss-loop-core.R
@@ -1,0 +1,60 @@
+# Tests for run_lss_voxel_loop_core
+
+test_that("run_lss_voxel_loop_core matches single voxel implementation", {
+  set.seed(123)
+  n <- 40
+  p <- 8
+  V <- 3
+  T_trials <- 5
+
+  # HRF shapes for each voxel
+  H_shapes <- matrix(rnorm(p * V), p, V)
+
+  # Trial design matrices
+  X_trials <- lapply(seq_len(T_trials), function(t) {
+    X <- matrix(0, n, p)
+    onset <- sample(1:(n - p), 1)
+    for (j in seq_len(p)) {
+      X[onset + j - 1, j] <- 1
+    }
+    X
+  })
+
+  # True trial amplitudes
+  Beta_true <- matrix(rnorm(T_trials * V), T_trials, V)
+
+  # Confounds and projection
+  A_fixed <- cbind(1, rnorm(n))
+  P_conf <- prepare_projection_matrix(A_fixed, 1e-6)
+
+  # Generate projected data
+  Y_clean <- matrix(0, n, V)
+  for (v in seq_len(V)) {
+    for (t in seq_len(T_trials)) {
+      Y_clean[, v] <- Y_clean[, v] + X_trials[[t]] %*% (H_shapes[, v] * Beta_true[t, v])
+    }
+  }
+  Y_proj <- P_conf %*% (Y_clean + matrix(rnorm(n * V, sd = 0.05), n, V))
+
+  Beta_core <- manifoldhrf:::run_lss_voxel_loop_core(
+    Y_proj_matrix = Y_proj,
+    X_trial_onset_list_of_matrices = X_trials,
+    H_shapes_allvox_matrix = H_shapes,
+    A_lss_fixed_matrix = A_fixed,
+    lambda_ridge = 1e-6,
+    n_jobs = 1
+  )
+
+  Beta_manual <- matrix(0, T_trials, V)
+  for (v in seq_len(V)) {
+    Beta_manual[, v] <- run_lss_for_voxel_corrected_full(
+      Y_proj_voxel_vector = Y_proj[, v],
+      X_trial_onset_list_of_matrices = X_trials,
+      H_shape_voxel_vector = H_shapes[, v],
+      P_confound = P_conf,
+      lambda_ridge = 1e-6
+    )
+  }
+
+  expect_equal(Beta_core, Beta_manual, tolerance = 1e-8)
+})

--- a/tests/testthat/test-mhrf-lss-parameters.R
+++ b/tests/testthat/test-mhrf-lss-parameters.R
@@ -1,0 +1,11 @@
+# Tests for mhrf_lss_parameters helper
+
+test_that("mhrf_lss_parameters merges preset and user values", {
+  base <- mhrf_lss_parameters("balanced")
+  override <- mhrf_lss_parameters("balanced", lambda_gamma = 0.05, use_parallel = TRUE)
+
+  expect_true(is.list(base))
+  expect_equal(override$lambda_gamma, 0.05)
+  expect_true(override$use_parallel)
+  expect_equal(base$m_manifold_dim_target, override$m_manifold_dim_target)
+})

--- a/tests/testthat/test-smart-initialize.R
+++ b/tests/testthat/test-smart-initialize.R
@@ -1,0 +1,80 @@
+# Tests for smart initialization and stuck voxel handling
+
+test_that("smart_initialize provides reasonable starting values", {
+  set.seed(123)
+  n <- 60
+  p <- 10
+  V <- 6
+  k <- 2
+  m <- 3
+
+  # canonical HRF
+  t_hrf <- seq(0, (p - 1) * 0.5, by = 0.5)
+  hrf <- dgamma(t_hrf, shape = 6, rate = 1)
+  hrf <- hrf / sum(hrf)
+
+  # simple event designs
+  X_list <- lapply(seq_len(k), function(c) {
+    X <- matrix(0, n, p)
+    onsets <- seq(5 + c, by = 20, length.out = 3)
+    for (o in onsets) {
+      if (o + p - 1 <= n) {
+        X[o:(o + p - 1), ] <- X[o:(o + p - 1), ] + diag(p)
+      }
+    }
+    X
+  })
+
+  # generate data with varying SNR
+  Y <- matrix(0, n, V)
+  betas <- matrix(runif(k * V, 0.5, 1.5), k, V)
+  noise_sd <- c(rep(0.1, V / 2), rep(1, V / 2))
+  for (v in seq_len(V)) {
+    for (c in seq_len(k)) {
+      Y[, v] <- Y[, v] + X_list[[c]] %*% (hrf * betas[c, v])
+    }
+    Y[, v] <- Y[, v] + rnorm(n, sd = noise_sd[v])
+  }
+
+  init <- smart_initialize(
+    Y_data = Y,
+    X_condition_list = X_list,
+    hrf_canonical = hrf,
+    use_spatial_clusters = FALSE,
+    m_manifold_dim = m
+  )
+
+  expect_equal(dim(init$Xi_init), c(m, V))
+  expect_equal(dim(init$Beta_init), c(k, V))
+  expect_length(init$R2_init, V)
+  expect_true(all(init$R2_init >= 0 & init$R2_init <= 1))
+  expect_true(all(init$good_voxels %in% seq_len(V)))
+
+  mean_good <- mean(init$R2_init[init$good_voxels])
+  mean_bad <- mean(init$R2_init[-init$good_voxels])
+  expect_gt(mean_good, mean_bad)
+})
+
+
+test_that("fix_stuck_voxels reinitializes low-variance columns", {
+  set.seed(456)
+  m <- 3
+  V <- 4
+  Xi_prev <- matrix(rnorm(m * V), m, V)
+  Xi_curr <- Xi_prev
+  Xi_curr[, c(1, 3)] <- Xi_curr[, c(1, 3)] + matrix(rnorm(m * 2, sd = 0.1), m, 2)
+
+  Xi_fixed <- fix_stuck_voxels(
+    Xi_current = Xi_curr,
+    Xi_previous = Xi_prev,
+    variance_threshold = 1e-4,
+    reinit_sd = 0.5
+  )
+
+  diff_stuck <- colSums((Xi_fixed[, c(2, 4)] - Xi_prev[, c(2, 4)])^2)
+  diff_ok <- colSums((Xi_fixed[, c(1, 3)] - Xi_curr[, c(1, 3)])^2)
+
+  expect_true(all(diff_stuck > 1e-4))
+  expect_true(all(diff_ok < 1e-6))
+  expect_equal(dim(Xi_fixed), dim(Xi_curr))
+})


### PR DESCRIPTION
## Summary
- add regression test for run_lss_voxel_loop_core against single-voxel routine
- add tests for smart_initialize and fix_stuck_voxels functions
- test mhrf_lss_parameters helper merging presets with overrides

## Testing
- `R CMD INSTALL .` *(fails: `R: command not found`)*
- `R -e "devtools::test()"` *(fails: `R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683c98506954832d8aa403203c95f53d