### PR TITLE
Fix LSS implementation to use Woodbury trial-wise solver

### DIFF
--- a/R/core_lss.R
+++ b/R/core_lss.R
@@ -114,17 +114,25 @@ run_lss_for_voxel_corrected_full <- function(Y_proj_voxel_vector,
 #' @param Y_proj_voxel_vector Projected data vector (n x 1)
 #' @param X_trial_onset_list_of_matrices List of trial design matrices
 #' @param H_shape_voxel_vector HRF shape vector (p x 1)
+#' @param P_confound Projection matrix used to remove confound effects
+#'   (n x n). If \code{NULL}, no projection is applied.
 #' @param lambda_ridge Ridge regularization parameter
 #' @return Vector of trial-wise betas
 #' @export
 run_lss_woodbury_corrected <- function(Y_proj_voxel_vector,
                                       X_trial_onset_list_of_matrices,
                                       H_shape_voxel_vector,
+                                      P_confound = NULL,
                                       lambda_ridge = 1e-6) {
   
   n <- length(Y_proj_voxel_vector)
   T_trials <- length(X_trial_onset_list_of_matrices)
   
+  if (is.null(P_confound)) {
+    # Identity projection if none supplied
+    P_confound <- diag(n)
+  }
+
   beta_trials <- numeric(T_trials)
   
   # For each trial, solve the LSS problem
@@ -133,6 +141,7 @@ run_lss_woodbury_corrected <- function(Y_proj_voxel_vector,
     # Create design matrix for this trial
     X_t <- X_trial_onset_list_of_matrices[[t]]
     C_t <- X_t %*% H_shape_voxel_vector
+    C_t <- P_confound %*% C_t
     
     # Create design matrix for all other trials
     other_trials <- setdiff(1:T_trials, t)
@@ -141,7 +150,7 @@ run_lss_woodbury_corrected <- function(Y_proj_voxel_vector,
       for (i in seq_along(other_trials)) {
         trial_idx <- other_trials[i]
         X_other <- X_trial_onset_list_of_matrices[[trial_idx]]
-        C_others[, i] <- X_other %*% H_shape_voxel_vector
+        C_others[, i] <- P_confound %*% (X_other %*% H_shape_voxel_vector)
       }
       
       # Full design matrix
@@ -193,7 +202,7 @@ prepare_projection_matrix <- function(Z_confounds, lambda = 1e-6) {
 #' Run LSS Across Voxels (Core)
 #'
 #' Computes trial-wise LSS estimates for all voxels using the
-#' mathematically correct implementation.
+#' Woodbury-based implementation.
 #'
 #' @param Y_proj_matrix n x V projected BOLD data matrix.
 #' @param X_trial_onset_list_of_matrices List of length T with n x p design matrices.
@@ -233,7 +242,7 @@ run_lss_voxel_loop_core <- function(Y_proj_matrix,
   P_confound <- prepare_projection_matrix(A_lss_fixed_matrix, lambda_ridge)
 
   voxel_fun <- function(v) {
-    run_lss_for_voxel_corrected_full(
+    run_lss_woodbury_corrected(
       Y_proj_voxel_vector = Y_proj_matrix[, v],
       X_trial_onset_list_of_matrices = X_trial_onset_list_of_matrices,
       H_shape_voxel_vector = H_shapes_allvox_matrix[, v],

--- a/man/run_lss_woodbury_corrected.Rd
+++ b/man/run_lss_woodbury_corrected.Rd
@@ -8,6 +8,7 @@ run_lss_woodbury_corrected(
   Y_proj_voxel_vector,
   X_trial_onset_list_of_matrices,
   H_shape_voxel_vector,
+  P_confound = NULL,
   lambda_ridge = 1e-06
 )
 }
@@ -17,6 +18,9 @@ run_lss_woodbury_corrected(
 \item{X_trial_onset_list_of_matrices}{List of trial design matrices}
 
 \item{H_shape_voxel_vector}{HRF shape vector (p x 1)}
+
+\item{P_confound}{Projection matrix used to remove confound effects. If
+\code{NULL}, no projection is applied.}
 
 \item{lambda_ridge}{Ridge regularization parameter}
 }

--- a/tests/testthat/helper-corrected.R
+++ b/tests/testthat/helper-corrected.R
@@ -9,7 +9,7 @@ run_lss_voxel_loop_corrected_test <- function(Y_matrix,
   Beta <- matrix(0, T_trials, V)
   for (v in seq_len(V)) {
     y_proj <- as.vector(P_conf %*% Y_matrix[, v])
-    Beta[, v] <- run_lss_for_voxel_corrected_full(
+    Beta[, v] <- run_lss_woodbury_corrected(
       Y_proj_voxel_vector = y_proj,
       X_trial_onset_list_of_matrices = X_trial_onset_list,
       H_shape_voxel_vector = H_shapes_matrix[, v],

--- a/tests/testthat/test-core-algorithm-diagnostics.R
+++ b/tests/testthat/test-core-algorithm-diagnostics.R
@@ -413,7 +413,7 @@ test_that("M-HRF-LSS trial-wise estimation is unbiased and efficient compared to
   test_voxel <- 5
   h_v <- hrf_true
   
-  beta_single <- run_lss_for_voxel_corrected_full(
+  beta_single <- run_lss_woodbury_corrected(
     Y_proj_voxel_vector = as.vector(Y_proj[, test_voxel]),
     X_trial_onset_list_of_matrices = X_trials,
     H_shape_voxel_vector = h_v,

--- a/tests/testthat/test-lss-loop-core.R
+++ b/tests/testthat/test-lss-loop-core.R
@@ -47,7 +47,7 @@ test_that("run_lss_voxel_loop_core matches single voxel implementation", {
 
   Beta_manual <- matrix(0, T_trials, V)
   for (v in seq_len(V)) {
-    Beta_manual[, v] <- run_lss_for_voxel_corrected_full(
+    Beta_manual[, v] <- run_lss_woodbury_corrected(
       Y_proj_voxel_vector = Y_proj[, v],
       X_trial_onset_list_of_matrices = X_trials,
       H_shape_voxel_vector = H_shapes[, v],


### PR DESCRIPTION
## Summary
- project trial regressors inside `run_lss_woodbury_corrected`
- support confound projection in `run_lss_woodbury_corrected`
- call the Woodbury version from `run_lss_voxel_loop_core`
- update helper and tests for the new LSS implementation
- document the updated parameter

## Testing
- `R -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f3a88ed00832da15e254725fc09bd