### PR TITLE
Refactor identifiability fallback

### DIFF
--- a/R/core_voxelfit_engine.R
+++ b/R/core_voxelfit_engine.R
@@ -365,38 +365,11 @@ apply_intrinsic_identifiability_core <- function(Xi_raw_matrix,
       if (is.na(corr_ref)) corr_ref <- 0
       if (abs(corr_ref) < 1e-3) {
         warning(sprintf("Voxel %d: canonical correlation near zero (%.3f)", v, corr_ref))
-      }
-      sgn <- sign(corr_ref)
-      if (sgn == 0) sgn <- 1
-      if (abs(corr_ref) < 1e-3 && !is.null(Y_proj_matrix) &&
-          !is.null(X_condition_list_proj_matrices)) {
-        best_r2 <- -Inf
-        best_sgn <- 1
-        for (sg in c(1, -1)) {
-          xi_tmp <- xi_v * sg
-          beta_tmp <- beta_v * sg
-          h_tmp2 <- B_reconstructor_matrix %*% xi_tmp
-          k2 <- length(X_condition_list_proj_matrices)
-          X_design <- matrix(0, nrow(Y_proj_matrix), k2)
-          for (c in 1:k2) {
-            X_design[, c] <- X_condition_list_proj_matrices[[c]] %*% h_tmp2
-          }
-          y_pred <- X_design %*% beta_tmp
-          y_true <- Y_proj_matrix[, v]
-          r2 <- tryCatch(cor(as.vector(y_pred), as.vector(y_true))^2, 
-                        warning = function(w) NA, 
-                        error = function(e) NA)
-          if (!is.na(r2) && r2 > best_r2) {
-            best_r2 <- r2
-            best_sgn <- sg
-          }
-        }
-        if (best_r2 > 0) {
-          sgn <- best_sgn
-        } else {
-          sgn <- sign(sum(h_tmp))
-          if (sgn == 0) sgn <- 1
-        }
+        sgn <- sign(sum(h_tmp))
+        if (sgn == 0) sgn <- 1
+      } else {
+        sgn <- sign(corr_ref)
+        if (sgn == 0) sgn <- 1
       }
     } else if (ident_sign_method == "data_fit_correlation") {
       best_r2 <- -Inf

--- a/data-raw/Manifold_hrf_proposal.md
+++ b/data-raw/Manifold_hrf_proposal.md
@@ -98,7 +98,10 @@ All components are designed for computational efficiency, primarily relying on c
             *   `xi_vx = Xi_raw_allvox[,vx]`, `beta_vx = Beta_raw_allvox[,vx]`.
             *   `reconstructed_hrf_vx_unscaled = B_reconstructor %*% xi_vx`.
             *   **Sign:**
-                *   If `ident_sign_method == "canonical_correlation"`: `sgn = sign(sum(xi_vx * xi_ref_coord))`.
+                *   If `ident_sign_method == "canonical_correlation"`:
+                    `corr_ref = cor(reconstructed_hrf_vx_unscaled, h_ref_shape_canonical)`;
+                    `sgn = sign(corr_ref)`.
+                    If `abs(corr_ref) < 1e-3`, use `sgn = sign(sum(reconstructed_hrf_vx_unscaled))`.
                 *   If `ident_sign_method == "data_fit_correlation"`: (Requires original `Y_proj` and `X_condition_list_proj` for this voxel) Estimate full model fit for `+sgn` and `-sgn` choice for `xi_vx`, choose sign that maximizes `R^2`.
             *   `xi_vx_signed = xi_vx * sgn`, `beta_vx_signed = beta_vx * sgn`.
             *   `reconstructed_hrf_vx_signed = B_reconstructor %*% xi_vx_signed`.

--- a/data-raw/Manifold_hrf_proposal.txt
+++ b/data-raw/Manifold_hrf_proposal.txt
@@ -98,7 +98,10 @@ All components are designed for computational efficiency, primarily relying on c
             *   `xi_vx = Xi_raw_allvox[,vx]`, `beta_vx = Beta_raw_allvox[,vx]`.
             *   `reconstructed_hrf_vx_unscaled = B_reconstructor %*% xi_vx`.
             *   **Sign:**
-                *   If `ident_sign_method == "canonical_correlation"`: `sgn = sign(sum(xi_vx * xi_ref_coord))`.
+                *   If `ident_sign_method == "canonical_correlation"`:
+                    `corr_ref = cor(reconstructed_hrf_vx_unscaled, h_ref_shape_canonical)`;
+                    `sgn = sign(corr_ref)`.
+                    If `abs(corr_ref) < 1e-3`, use `sgn = sign(sum(reconstructed_hrf_vx_unscaled))`.
                 *   If `ident_sign_method == "data_fit_correlation"`: (Requires original `Y_proj` and `X_condition_list_proj` for this voxel) Estimate full model fit for `+sgn` and `-sgn` choice for `xi_vx`, choose sign that maximizes `R^2`.
             *   `xi_vx_signed = xi_vx * sgn`, `beta_vx_signed = beta_vx * sgn`.
             *   `reconstructed_hrf_vx_signed = B_reconstructor %*% xi_vx_signed`.

--- a/man/apply_intrinsic_identifiability_core.Rd
+++ b/man/apply_intrinsic_identifiability_core.Rd
@@ -69,8 +69,9 @@ It ensures that HRF estimates are identifiable by:
 \item Aligning sign with a reference HRF (avoiding arbitrary sign flips)
 \item Normalizing scale consistently across voxels
 The chosen sign alignment method is reported via messages. When the
-correlation with the canonical HRF is near zero, a warning is produced and
-a fallback RMS-based alignment is attempted. Setting
+absolute correlation with the canonical HRF falls below \code{1e-3}, a
+warning is produced and the sign is determined using the RMS rule
+(the sign of the sum of the HRF). Setting
 \code{consistency_check = TRUE} reprojects each HRF and revalidates the sign.
 The beta amplitudes are adjusted inversely to preserve the overall signal.
 Voxels whose reconstructed HRFs fall below \code{zero_tol} are zeroed in

--- a/tests/testthat/test-identifiability-fallback.R
+++ b/tests/testthat/test-identifiability-fallback.R
@@ -1,0 +1,49 @@
+context("identifiability fallback")
+
+set.seed(42)
+
+# Simple identity reconstructor for clarity
+B <- diag(3)
+# reference HRF aligned with third basis vector
+h_ref <- c(0, 0, 1)
+
+Xi_raw <- matrix(c(-1, 0, 0), nrow = 3, ncol = 1)
+Beta_raw <- matrix(1, nrow = 1, ncol = 1)
+
+# provide projected data and designs even though they should be ignored
+Y_proj <- matrix(rnorm(3), 3, 1)
+X_list <- list(matrix(rnorm(3 * 3), 3, 3))
+
+res <- apply_intrinsic_identifiability_core(
+  Xi_raw_matrix = Xi_raw,
+  Beta_raw_matrix = Beta_raw,
+  B_reconstructor_matrix = B,
+  h_ref_shape_vector = h_ref,
+  Y_proj_matrix = Y_proj,
+  X_condition_list_proj_matrices = X_list,
+  ident_sign_method = "canonical_correlation"
+)
+
+# Correlation with h_ref is zero so RMS rule should flip sign
+
+test_that("canonical correlation falls back to RMS rule", {
+  expect_equal(res$Xi_ident_matrix[1, 1] > 0, TRUE)
+  expect_equal(res$Beta_ident_matrix[1, 1] < 0, TRUE)
+})
+
+Xi_raw2 <- matrix(c(1, 0, 0), nrow = 3, ncol = 1)
+Beta_raw2 <- matrix(1, nrow = 1, ncol = 1)
+res2 <- apply_intrinsic_identifiability_core(
+  Xi_raw_matrix = Xi_raw2,
+  Beta_raw_matrix = Beta_raw2,
+  B_reconstructor_matrix = B,
+  h_ref_shape_vector = h_ref,
+  Y_proj_matrix = Y_proj,
+  X_condition_list_proj_matrices = X_list,
+  ident_sign_method = "canonical_correlation"
+)
+
+test_that("RMS fallback preserves positive sign", {
+  expect_equal(res2$Xi_ident_matrix[1, 1] > 0, TRUE)
+  expect_equal(res2$Beta_ident_matrix[1, 1] > 0, TRUE)
+})


### PR DESCRIPTION
## Summary
- simplify `.process_voxel_identifiability()` to skip the data-fit fallback
- update engine logic to use RMS rule when canonical correlation is low
- clarify fallback behaviour in documentation and proposal
- add regression tests covering the RMS fallback

## Testing
- `roxygen2::roxygenise()` *(fails: `bash: R: command not found`)*
- `devtools::test()` *(fails: `bash: R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f3bb7f8e4832dab4018a01f2dcdb2