### PR TITLE
Add RAM heuristic precomputation option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,8 @@ The pipeline consists of 5 main components (0-4) plus pre-flight QC (-1):
 - `reconstruct_hrf_shapes_core()`: Transform smoothed manifold coords back to HRF shapes
 - `run_lss_for_voxel_core()`: Woodbury-optimized LSS for single voxel
 - `run_lss_voxel_loop_core()`: Main loop with optional RAM-based precomputation
+  controlled by `ram_heuristic_GB_for_Rt`. Trial regressors are precomputed
+  when `T * V * 8 / 1e9` is below this limit.
 
 **Component 4: Alternating Optimization**
 - `estimate_final_condition_betas_core()`: Re-estimate condition betas using final HRFs
@@ -97,7 +99,8 @@ The pipeline consists of 5 main components (0-4) plus pre-flight QC (-1):
 2. **Memory Management**:
    - Sparse matrix support for large HRF libraries (N > 5000)
    - Optional HDF5 backing for very large datasets
-   - RAM heuristics for trial-wise precomputation
+  - RAM heuristics for trial-wise precomputation via
+    `ram_heuristic_GB_for_Rt` in `run_lss_voxel_loop_core`
 
 3. **Numerical Stability**:
    - Ridge regularization throughout

--- a/tests/testthat/test-lss-loop-core.R
+++ b/tests/testthat/test-lss-loop-core.R
@@ -42,7 +42,62 @@ test_that("run_lss_voxel_loop_core matches single voxel implementation", {
     H_shapes_allvox_matrix = H_shapes,
     A_lss_fixed_matrix = A_fixed,
     lambda_ridge = 1e-6,
-    n_jobs = 1
+    n_jobs = 1,
+    ram_heuristic_GB_for_Rt = 1.0
+  )
+
+  Beta_manual <- matrix(0, T_trials, V)
+  for (v in seq_len(V)) {
+    Beta_manual[, v] <- run_lss_for_voxel_corrected_full(
+      Y_proj_voxel_vector = Y_proj[, v],
+      X_trial_onset_list_of_matrices = X_trials,
+      H_shape_voxel_vector = H_shapes[, v],
+      P_confound = P_conf,
+      lambda_ridge = 1e-6
+    )
+  }
+
+  expect_equal(Beta_core, Beta_manual, tolerance = 1e-8)
+})
+
+test_that("run_lss_voxel_loop_core works without precomputation", {
+  set.seed(123)
+  n <- 40
+  p <- 8
+  V <- 3
+  T_trials <- 5
+
+  H_shapes <- matrix(rnorm(p * V), p, V)
+  X_trials <- lapply(seq_len(T_trials), function(t) {
+    X <- matrix(0, n, p)
+    onset <- sample(1:(n - p), 1)
+    for (j in seq_len(p)) {
+      X[onset + j - 1, j] <- 1
+    }
+    X
+  })
+
+  Beta_true <- matrix(rnorm(T_trials * V), T_trials, V)
+
+  A_fixed <- cbind(1, rnorm(n))
+  P_conf <- prepare_projection_matrix(A_fixed, 1e-6)
+
+  Y_clean <- matrix(0, n, V)
+  for (v in seq_len(V)) {
+    for (t in seq_len(T_trials)) {
+      Y_clean[, v] <- Y_clean[, v] + X_trials[[t]] %*% (H_shapes[, v] * Beta_true[t, v])
+    }
+  }
+  Y_proj <- P_conf %*% (Y_clean + matrix(rnorm(n * V, sd = 0.05), n, V))
+
+  Beta_core <- manifoldhrf:::run_lss_voxel_loop_core(
+    Y_proj_matrix = Y_proj,
+    X_trial_onset_list_of_matrices = X_trials,
+    H_shapes_allvox_matrix = H_shapes,
+    A_lss_fixed_matrix = A_fixed,
+    lambda_ridge = 1e-6,
+    n_jobs = 1,
+    ram_heuristic_GB_for_Rt = 0
   )
 
   Beta_manual <- matrix(0, T_trials, V)


### PR DESCRIPTION
## Summary
- add `ram_heuristic_GB_for_Rt` parameter to `run_lss_voxel_loop_core`
- implement optional precomputation of trial regressors when memory allows
- document RAM heuristic in CLAUDE.md
- update tests for precomputed and non-precomputed paths

## Testing
- `devtools::document()` *(fails: R not installed)*
- `devtools::test()` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f3bd679f0832db8c0b3c34c8d78e9