### PR TITLE
Implement redesigned LSS workflow

### DIFF
--- a/R/core_lss_deprecated.R
+++ b/R/core_lss_deprecated.R
@@ -235,31 +235,6 @@ reconstruct_hrf_shapes_core <- function(B_reconstructor_matrix,
 }
 
 #' Compute trial-wise betas using the Woodbury identity
-#'
-#' Internal helper used by LSS functions to compute single-trial betas
-#' given the voxel-specific trial regressor matrix.
-#'
-#' @param C_v Matrix of convolved trial regressors (n x T)
-#' @param Y_v Numeric vector of length n with projected voxel data
-#' @param A_fixed Fixed regressors matrix used during projection (n x q)
-#' @param P_lss Precomputed matrix from `prepare_lss_fixed_components_core`
-#'              with dimensions q x n
-#' @param p_lss Precomputed intercept projection vector of length n
-#'
-#' @return Numeric vector of length T containing LSS beta estimates
-#' @keywords internal
-.compute_lss_betas <- function(C_v, Y_v, A_fixed, P_lss, p_lss) {
-  U_v <- P_lss %*% C_v
-  V_regressors_v <- C_v - A_fixed %*% U_v
-  pc_v_row <- as.vector(crossprod(p_lss, C_v))
-  cv_v_row <- colSums(V_regressors_v * V_regressors_v)
-  alpha_v_row <- (1 - pc_v_row) / pmax(cv_v_row, .Machine$double.eps)
-  S_effective_regressors_v <- sweep(V_regressors_v, MARGIN = 2,
-                                    STATS = alpha_v_row, FUN = "*")
-  S_effective_regressors_v <- sweep(S_effective_regressors_v, MARGIN = 1,
-                                    STATS = p_lss, FUN = "+")
-  as.vector(crossprod(S_effective_regressors_v, Y_v))
-}
 
 #' Run LSS for Single Voxel (Core)
 

--- a/R/mhrf_lss_interface.R
+++ b/R/mhrf_lss_interface.R
@@ -548,7 +548,8 @@ run_mhrf_lss_standard <- function(Y_data, design_info, manifold, Z_confounds,
       X_trial_onset_list_of_matrices = design_info$X_trial_list,
       H_shapes_allvox_matrix = H_shapes,
       A_lss_fixed_matrix = Z_confounds,
-      lambda_ridge = params$lambda_ridge_Alss %||% 1e-6,
+      P_lss_matrix = lss_prep$P_lss_matrix,
+      p_lss_vector = lss_prep$p_lss_vector,
       n_jobs = params$n_jobs %||% 1
     )
   }

--- a/man/run_lss_for_voxel_corrected_full.Rd
+++ b/man/run_lss_for_voxel_corrected_full.Rd
@@ -8,8 +8,9 @@ run_lss_for_voxel_corrected_full(
   Y_proj_voxel_vector,
   X_trial_onset_list_of_matrices,
   H_shape_voxel_vector,
-  P_confound,
-  lambda_ridge = 1e-06
+  A_lss_fixed_matrix,
+  P_lss_matrix,
+  p_lss_vector
 )
 }
 \arguments{
@@ -19,13 +20,15 @@ run_lss_for_voxel_corrected_full(
 
 \item{H_shape_voxel_vector}{HRF shape (p x 1)}
 
-\item{P_confound}{Projection matrix that removes confounds (n x n)}
+\item{A_lss_fixed_matrix}{Matrix of fixed regressors used during projection (n x q)}
 
-\item{lambda_ridge}{Ridge regularization parameter}
+\item{P_lss_matrix}{Precomputed matrix from \code{prepare_lss_fixed_components_core} (q x n)}
+
+\item{p_lss_vector}{Precomputed intercept projection vector of length n}
 }
 \value{
 Vector of trial-wise betas
 }
 \description{
-Complete interface that takes projected data and projection matrices
+Complete interface using precomputed LSS components
 }

--- a/tests/testthat/test-core-voxelfit-engine.R
+++ b/tests/testthat/test-core-voxelfit-engine.R
@@ -67,9 +67,17 @@ test_that("run_lss_for_voxel_corrected_full returns vector of length T", {
   X_list <- list(matrix(1:5, ncol = 1), matrix(5:1, ncol = 1))
   H <- rnorm(1)
   A <- cbind(1, matrix(rnorm(10), 5, 2))
+  lss_prep <- prepare_lss_fixed_components_core(A, 1, 0.01)
   P <- prepare_projection_matrix(A, 0.01)
   Y_proj <- as.vector(P %*% Y)
-  res <- run_lss_for_voxel_corrected_full(Y_proj, X_list, H, P, lambda_ridge = 0.01)
+  res <- run_lss_for_voxel_corrected_full(
+    Y_proj_voxel_vector = Y_proj,
+    X_trial_onset_list_of_matrices = X_list,
+    H_shape_voxel_vector = H,
+    A_lss_fixed_matrix = A,
+    P_lss_matrix = lss_prep$P_lss_matrix,
+    p_lss_vector = lss_prep$p_lss_vector
+  )
   expect_length(res, length(X_list))
 })
 

--- a/tests/testthat/test-lss-correction-validation.R
+++ b/tests/testthat/test-lss-correction-validation.R
@@ -61,12 +61,19 @@ test_that("Corrected LSS implementation matches ground truth", {
   }
   
   # METHOD 2: Corrected implementation
+  lss_prep <- prepare_lss_fixed_components_core(
+    A_lss_fixed_matrix = Z,
+    intercept_col_index_in_Alss = 1,
+    lambda_ridge_Alss = lambda
+  )
+
   betas_corrected <- run_lss_for_voxel_corrected_full(
     Y_proj_voxel_vector = y_proj,
     X_trial_onset_list_of_matrices = X_trials,
     H_shape_voxel_vector = h,
-    P_confound = P_proj,
-    lambda_ridge = lambda
+    A_lss_fixed_matrix = Z,
+    P_lss_matrix = lss_prep$P_lss_matrix,
+    p_lss_vector = lss_prep$p_lss_vector
   )
   
   # METHOD 3: Current Woodbury implementation

--- a/tests/testthat/test-lss-formula-verification.R
+++ b/tests/testthat/test-lss-formula-verification.R
@@ -84,14 +84,16 @@ test_that("Current LSS formula matches reference implementation", {
   # Now run the full current implementation
   betas_current <- numeric(T_trials)
   for (t in 1:T_trials) {
+    lss_prep <- prepare_lss_fixed_components_core(A, 1, lambda)
     beta_t <- run_lss_for_voxel_corrected_full(
       Y_proj_voxel_vector = y_proj,
       X_trial_onset_list_of_matrices = lapply(1:T_trials, function(i) {
         if (i == t) matrix(C[, i], ncol = 1) else matrix(0, n, 1)
       }),
       H_shape_voxel_vector = rep(1, 1),
-      P_confound = prepare_projection_matrix(A, lambda),
-      lambda_ridge = lambda
+      A_lss_fixed_matrix = A,
+      P_lss_matrix = lss_prep$P_lss_matrix,
+      p_lss_vector = lss_prep$p_lss_vector
     )
     betas_current[t] <- beta_t[t]
   }

--- a/tests/testthat/test-lss-loop-core.R
+++ b/tests/testthat/test-lss-loop-core.R
@@ -25,6 +25,7 @@ test_that("run_lss_voxel_loop_core matches single voxel implementation", {
 
   # Confounds and projection
   A_fixed <- cbind(1, rnorm(n))
+  lss_prep <- prepare_lss_fixed_components_core(A_fixed, 1, 1e-6)
   P_conf <- prepare_projection_matrix(A_fixed, 1e-6)
 
   # Generate projected data
@@ -41,7 +42,8 @@ test_that("run_lss_voxel_loop_core matches single voxel implementation", {
     X_trial_onset_list_of_matrices = X_trials,
     H_shapes_allvox_matrix = H_shapes,
     A_lss_fixed_matrix = A_fixed,
-    lambda_ridge = 1e-6,
+    P_lss_matrix = lss_prep$P_lss_matrix,
+    p_lss_vector = lss_prep$p_lss_vector,
     n_jobs = 1,
     ram_heuristic_GB_for_Rt = 1.0
   )
@@ -52,8 +54,9 @@ test_that("run_lss_voxel_loop_core matches single voxel implementation", {
       Y_proj_voxel_vector = Y_proj[, v],
       X_trial_onset_list_of_matrices = X_trials,
       H_shape_voxel_vector = H_shapes[, v],
-      P_confound = P_conf,
-      lambda_ridge = 1e-6
+      A_lss_fixed_matrix = A_fixed,
+      P_lss_matrix = lss_prep$P_lss_matrix,
+      p_lss_vector = lss_prep$p_lss_vector
     )
   }
 
@@ -80,6 +83,7 @@ test_that("run_lss_voxel_loop_core works without precomputation", {
   Beta_true <- matrix(rnorm(T_trials * V), T_trials, V)
 
   A_fixed <- cbind(1, rnorm(n))
+  lss_prep <- prepare_lss_fixed_components_core(A_fixed, 1, 1e-6)
   P_conf <- prepare_projection_matrix(A_fixed, 1e-6)
 
   Y_clean <- matrix(0, n, V)
@@ -95,7 +99,8 @@ test_that("run_lss_voxel_loop_core works without precomputation", {
     X_trial_onset_list_of_matrices = X_trials,
     H_shapes_allvox_matrix = H_shapes,
     A_lss_fixed_matrix = A_fixed,
-    lambda_ridge = 1e-6,
+    P_lss_matrix = lss_prep$P_lss_matrix,
+    p_lss_vector = lss_prep$p_lss_vector,
     n_jobs = 1,
     ram_heuristic_GB_for_Rt = 0
   )
@@ -106,8 +111,9 @@ test_that("run_lss_voxel_loop_core works without precomputation", {
       Y_proj_voxel_vector = Y_proj[, v],
       X_trial_onset_list_of_matrices = X_trials,
       H_shape_voxel_vector = H_shapes[, v],
-      P_confound = P_conf,
-      lambda_ridge = 1e-6
+      A_lss_fixed_matrix = A_fixed,
+      P_lss_matrix = lss_prep$P_lss_matrix,
+      p_lss_vector = lss_prep$p_lss_vector
     )
   }
 


### PR DESCRIPTION
## Summary
- move internal `.compute_lss_betas` helper into main LSS file
- rewrite `run_lss_for_voxel_corrected_full` to use precomputed LSS components
- update `run_lss_voxel_loop_core` and interface to pass precomputed values
- revise tests for the new API and document changes

## Testing
- `devtools::test()` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f40c8af48832d9128d107bda0138c