### PR TITLE
Add utility and simulation tests

### DIFF
--- a/tests/testthat/test-adjust_hrf_utils.R
+++ b/tests/testthat/test-adjust_hrf_utils.R
@@ -1,0 +1,27 @@
+library(testthat)
+
+# Tests for adjust_hrf_for_bounds and .validate_and_standardize_lambda
+
+
+test_that("adjust_hrf_for_bounds truncates and pads correctly", {
+  hrf <- 1:5
+  expect_warning(trunc <- adjust_hrf_for_bounds(hrf, 3), "HRF truncated")
+  expect_equal(trunc, 1:3)
+
+  padded <- adjust_hrf_for_bounds(hrf, 7)
+  expect_equal(length(padded), 7)
+  expect_equal(padded[1:5], hrf)
+  expect_true(all(padded[6:7] == 0))
+
+  expect_error(adjust_hrf_for_bounds("bad", 3), "numeric")
+})
+
+test_that(".validate_and_standardize_lambda validates input", {
+  expect_error(manifoldhrf:::`.validate_and_standardize_lambda`(-1, "lambda"),
+               "non-negative")
+  expect_error(manifoldhrf:::`.validate_and_standardize_lambda`(c(1,2), "lambda"),
+               "non-negative")
+  expect_equal(manifoldhrf:::`.validate_and_standardize_lambda`(0.5, "lambda"),
+               0.5)
+  expect_equal(manifoldhrf:::`.validate_and_standardize_lambda`(2L, "lambda"), 2)
+})

--- a/tests/testthat/test-simulate-dataset.R
+++ b/tests/testthat/test-simulate-dataset.R
@@ -19,3 +19,34 @@ test_that("simulate_mhrf_dataset creates valid dataset", {
   expect_s3_class(sim$dataset, "matrix_dataset")
 })
 
+
+test_that("simulate_mhrf_dataset respects variability and noise parameters", {
+  set.seed(42)
+  sim_none <- simulate_mhrf_dataset(
+    n_voxels = 5,
+    n_timepoints = 40,
+    n_trials = 2,
+    n_conditions = 2,
+    hrf_variability = "none",
+    noise_level = 0
+  )
+
+  hrfs <- sim_none$ground_truth$hrfs$matrix
+  diffs <- apply(hrfs, 2, function(col) max(abs(col - hrfs[,1])))
+  expect_true(all(diffs < 1e-8))
+
+  dvars_zero <- manifoldhrf:::`compute_dvars`(sim_none$bold_data)
+
+  set.seed(42)
+  sim_noise <- simulate_mhrf_dataset(
+    n_voxels = 5,
+    n_timepoints = 40,
+    n_trials = 2,
+    n_conditions = 2,
+    hrf_variability = "none",
+    noise_level = 5
+  )
+  dvars_noise <- manifoldhrf:::`compute_dvars`(sim_noise$bold_data)
+
+  expect_gt(dvars_noise, dvars_zero)
+})


### PR DESCRIPTION
## Summary
- add tests for `adjust_hrf_for_bounds` and `.validate_and_standardize_lambda`
- extend `simulate_mhrf_dataset` tests for HRF variability and noise handling

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e601ca68832d98f9d9b3d48bcdf4