### PR TITLE
Optimize edge weight computation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,8 @@ Suggests:
     future.apply,
     parallel,
     proxy,
-    RcppHNSW
+    RcppHNSW,
+    microbenchmark
 VignetteBuilder: knitr, rmarkdown
 URL: https://github.com/bbuchsbaum/manifold_hrf
 BugReports: https://github.com/bbuchsbaum/manifold_hrf/issues 

--- a/man/compute_edge_weights.Rd
+++ b/man/compute_edge_weights.Rd
@@ -4,7 +4,12 @@
 \alias{compute_edge_weights}
 \title{Compute Edge Weights for Edge-Preserving Smoothing}
 \usage{
-compute_edge_weights(Xi_matrix, voxel_coords, edge_threshold = 2)
+compute_edge_weights(
+  Xi_matrix,
+  voxel_coords,
+  edge_threshold = 2,
+  n_neighbors = 26
+)
 }
 \arguments{
 \item{Xi_matrix}{m x V manifold coordinates}
@@ -12,6 +17,8 @@ compute_edge_weights(Xi_matrix, voxel_coords, edge_threshold = 2)
 \item{voxel_coords}{V x 3 spatial coordinates}
 
 \item{edge_threshold}{Threshold for edge detection}
+
+\item{n_neighbors}{Number of nearest neighbors used for gradient computation}
 }
 \value{
 Vector of edge weights (0 = edge, 1 = smooth region)

--- a/tests/testthat/test-edge-weight-benchmark.R
+++ b/tests/testthat/test-edge-weight-benchmark.R
@@ -1,0 +1,41 @@
+library(manifoldhrf)
+
+compute_edge_weights_old <- function(Xi_matrix, voxel_coords, edge_threshold = 2) {
+  V <- ncol(Xi_matrix)
+  edge_weights <- rep(1, V)
+  for (v in seq_len(V)) {
+    voxel_v_matrix <- matrix(rep(voxel_coords[v, ], each = V), nrow = V, ncol = 3)
+    distances <- sqrt(rowSums((voxel_coords - voxel_v_matrix)^2))
+    neighbors <- which(distances > 0 & distances < 2)
+    if (length(neighbors) > 0) {
+      xi_v <- Xi_matrix[, v]
+      xi_neighbors <- Xi_matrix[, neighbors, drop = FALSE]
+      gradient_mag <- mean(colSums((xi_neighbors - xi_v)^2))
+      if (gradient_mag > edge_threshold) {
+        edge_weights[v] <- exp(-gradient_mag / edge_threshold)
+      }
+    }
+  }
+  edge_weights
+}
+
+
+test_that("optimized compute_edge_weights is faster", {
+  skip_if_not_installed("microbenchmark")
+
+  set.seed(123)
+  coords <- as.matrix(expand.grid(x = 1:10, y = 1:10, z = 1:3))
+  V <- nrow(coords)
+  Xi <- matrix(rnorm(3 * V), 3, V)
+
+  bm <- microbenchmark::microbenchmark(
+    old = compute_edge_weights_old(Xi, coords),
+    new = compute_edge_weights(Xi, coords),
+    times = 3L
+  )
+
+  median_old <- median(bm$time[bm$expr == "old"])
+  median_new <- median(bm$time[bm$expr == "new"])
+
+  expect_lt(median_new, median_old)
+})


### PR DESCRIPTION
## Summary
- compute neighbors once in `compute_edge_weights`
- document new `n_neighbors` argument
- depend on `microbenchmark`
- benchmark test for `compute_edge_weights` speed

## Testing
- `Rscript -e '1+1'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684720278830832d841746fe8c426682