### PR TITLE
Enable parallel final beta estimation

### DIFF
--- a/man/estimate_final_condition_betas_core.Rd
+++ b/man/estimate_final_condition_betas_core.Rd
@@ -9,7 +9,8 @@ estimate_final_condition_betas_core(
   X_condition_list_proj_matrices,
   H_shapes_allvox_matrix,
   lambda_beta_final = 0.01,
-  control_alt_list = list(max_iter = 1, rel_change_tol = 1e-04)
+  control_alt_list = list(max_iter = 1, rel_change_tol = 1e-04),
+  n_jobs = 1
 )
 }
 \arguments{
@@ -31,6 +32,7 @@ HRF shapes from Component 3}
 \item \code{rel_change_tol}: Relative change tolerance for convergence
 (default 1e-4)
 }}
+\item{n_jobs}{Number of parallel workers for voxel-wise computation.}
 }
 \value{
 Beta_condition_final_matrix A k x V matrix of final condition-level
@@ -80,7 +82,8 @@ H_shapes <- matrix(rnorm(p * V), p, V)
 Beta_final <- estimate_final_condition_betas_core(
   Y_proj, X_cond_list, H_shapes,
   lambda_beta_final = 0.01,
-  control_alt_list = list(max_iter = 1)
+  control_alt_list = list(max_iter = 1),
+  n_jobs = 1
 )
 }
 

--- a/tests/testthat/test-alternating-optimization.R
+++ b/tests/testthat/test-alternating-optimization.R
@@ -307,3 +307,27 @@ test_that("estimate_final_condition_betas_core recovers known signal patterns", 
   cor_clean <- cor(as.vector(true_betas), as.vector(Beta_estimated))
   expect_gt(cor_clean, 0.9)
 })
+
+test_that("estimate_final_condition_betas_core parallel matches serial", {
+  set.seed(111)
+  n <- 40
+  p <- 10
+  k <- 2
+  V <- 8
+
+  Y <- matrix(rnorm(n * V), n, V)
+  X_list <- lapply(seq_len(k), function(i) matrix(rnorm(n * p), n, p))
+  H <- matrix(rnorm(p * V), p, V)
+
+  beta_seq <- estimate_final_condition_betas_core(
+    Y, X_list, H,
+    n_jobs = 1
+  )
+
+  beta_par <- estimate_final_condition_betas_core(
+    Y, X_list, H,
+    n_jobs = 2
+  )
+
+  expect_equal(beta_seq, beta_par)
+})


### PR DESCRIPTION
## Summary
- add `n_jobs` argument to `estimate_final_condition_betas_core`
- compute betas for each voxel using `.parallel_lapply`
- update documentation
- test parallel vs sequential consistency

## Testing
- `R -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847202403f4832d9b6b27d01851a6b9