### PR TITLE
Update design info extraction

### DIFF
--- a/R/neuroimaging_wrappers.R
+++ b/R/neuroimaging_wrappers.R
@@ -484,7 +484,9 @@ process_subject_mhrf_lss_nim <- function(bold_input, mask_input, event_input,
   
   ev_model <- fmrireg::event_model(onset ~ hrf(condition, basis = manifold_objects$manifold_hrf_basis),
                                    data = events, block = ~ block, sampling_frame = sframe, drop_empty = TRUE)
-  design_info <- extract_design_info(ev_model, sframe)
+  term <- stats::terms(ev_model)[[1]]
+  raw_hrf <- term$hrf
+  design_info <- extract_design_info(ev_model, sframe, raw_hrf)
 
   result <- run_mhrf_lss_standard(
     Y_data = Y_mat,

--- a/man/extract_design_info.Rd
+++ b/man/extract_design_info.Rd
@@ -4,7 +4,7 @@
 \alias{extract_design_info}
 \title{Extract Design Information from fmrireg Event Model}
 \usage{
-extract_design_info(event_model, sframe)
+extract_design_info(event_model, sframe, raw_hrf)
 }
 \description{
 Extract Design Information from fmrireg Event Model


### PR DESCRIPTION
## Summary
- extract design matrices using fmrireg helpers
- propagate raw HRF argument
- document `raw_hrf` for `extract_design_info`

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684995865f24832d8bffd7554455bb43